### PR TITLE
Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: cpp
 
-cache: # see https://docs.travis-ci.com/user/caching/
-- directories:
-  - $HOME/.cache
+cache: ccache
 
 before_install:
   # fix linkage error with clang
@@ -18,16 +16,10 @@ script:
 # create build folder
 - mkdir build
 - cd build
-# restore cache if it exists
-- ([ ! -f $HOME/.cache/z3 ] || mv $HOME/.cache/z3 ./)
 # set compiler, python executable, and Z3 build verbosity
 - cmake -DCMAKE_CXX_COMPILER=$COMPILER -DPYTHON_EXECUTABLE=$(which $PY_CMD) -DBUILD_Z3_VERBOSE=TRUE ..
-# build Z3 (takes some time) and cache it
-- make -j2 z3
-- mkdir -p $HOME/.cache
-- mv -n z3/ $HOME/.cache/
 # build fiction
-- make -j2 fiction
+- make -j2
 # run integration tests
 - ./fiction -ef ../test/integration.fc -l log.json
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: cpp
 
-cache: ccache
+cache:
+  directories:
+    # cache Z3 build
+    - z3/
 
 before_install:
   # fix linkage error with clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
 
 script:
 # create build folder
-- mkdir build
+- mkdir -p build
 - cd build
 # set compiler, python executable, and Z3 build verbosity
 - cmake -DCMAKE_CXX_COMPILER=$COMPILER -DPYTHON_EXECUTABLE=$(which $PY_CMD) -DBUILD_Z3_VERBOSE=TRUE ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,6 @@ matrix:
     compiler: gcc
     addons:
       apt:
-        sources:
-          - ubuntu-toolchain-r-test
-          - boost-latest
         packages:
           - libboost-all-dev
     
@@ -45,8 +42,5 @@ matrix:
     compiler: clang
     addons:
       apt:
-        sources:
-          - ubuntu-toolchain-r-test
-          - boost-latest
         packages:
           - libboost-all-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: cpp
 cache:
   directories:
     # cache Z3 build
-    - z3/
+    - build/z3/
 
 before_install:
   # fix linkage error with clang


### PR DESCRIPTION
Use library caching correctly to significantly speed up build time from 20+ minutes to ~9 minutes.