### PR TITLE
macOS fix for `read_fqca_layout`

### DIFF
--- a/include/fiction/io/read_fqca_layout.hpp
+++ b/include/fiction/io/read_fqca_layout.hpp
@@ -8,6 +8,8 @@
 #include "../technology/cell_technologies.hpp"
 #include "../traits.hpp"
 
+#include <fmt/format.h>
+
 #include <cctype>
 #include <fstream>
 #include <iostream>

--- a/include/fiction/io/read_fqca_layout.hpp
+++ b/include/fiction/io/read_fqca_layout.hpp
@@ -8,11 +8,8 @@
 #include "../technology/cell_technologies.hpp"
 #include "../traits.hpp"
 
-#include <fmt/format.h>
-
 #include <cctype>
 #include <fstream>
-#include <iostream>
 #include <istream>
 #include <regex>
 #include <sstream>
@@ -104,7 +101,6 @@ class read_fqca_layout_impl
         {
             // remove all white space from the line to make regex matching easier and more robust
             const auto substituted_line = std::regex_replace(line, qca_stack::re_white_space, "");
-            std::cout << fmt::format("substituted line {}: '{}'", line_number, substituted_line) << std::endl;
 
             // skip empty lines
             if (!line.empty())
@@ -165,8 +161,6 @@ class read_fqca_layout_impl
                             }
                             else
                             {
-                                std::cout << "undefined cell label" << std::endl;
-                                std::cout << fmt::format("line {}: '{}'", line_number, substituted_line) << std::endl;
                                 throw undefined_cell_label_exception(cell_id);
                             }
                         }
@@ -213,8 +207,6 @@ class read_fqca_layout_impl
                         }
                         else
                         {
-                            std::cout << "undefined cell definition" << std::endl;
-                            std::cout << fmt::format("line {}: '{}'", line_number, substituted_line) << std::endl;
                             throw unrecognized_cell_definition_exception(line_number);
                         }
                     }
@@ -290,8 +282,6 @@ class read_fqca_layout_impl
         }
         else
         {
-            std::cout << "unsupported character" << std::endl;
-            std::cout << fmt::format("cell: {}, char: '{}'", cell, c) << std::endl;
             throw unsupported_character_exception(c);
         }
 

--- a/include/fiction/io/read_fqca_layout.hpp
+++ b/include/fiction/io/read_fqca_layout.hpp
@@ -162,7 +162,7 @@ class read_fqca_layout_impl
                         else
                         {
                             std::cout << "undefined cell label" << std::endl;
-                            std::cout << "line: " << line << std::endl;
+                            std::cout << fmt::format("line {}: '{}'", line_number, line) << std::endl;
                             throw undefined_cell_label_exception(cell_id);
                         }
                     }
@@ -210,7 +210,7 @@ class read_fqca_layout_impl
                     else
                     {
                         std::cout << "undefined cell definition" << std::endl;
-                        std::cout << "line: " << line << std::endl;
+                        std::cout << fmt::format("line {}: '{}'", line_number, line) << std::endl;
                         throw unrecognized_cell_definition_exception(line_number);
                     }
                 }
@@ -286,7 +286,7 @@ class read_fqca_layout_impl
         else
         {
             std::cout << "unsupported character" << std::endl;
-            std::cout << "char: " << c << std::endl;
+            std::cout << fmt::format("cell: {}, char: '{}'", cell, c) << std::endl;
             throw unsupported_character_exception(c);
         }
 

--- a/include/fiction/io/read_fqca_layout.hpp
+++ b/include/fiction/io/read_fqca_layout.hpp
@@ -8,8 +8,6 @@
 #include "../technology/cell_technologies.hpp"
 #include "../traits.hpp"
 
-#include <lorina/detail/utils.hpp>
-
 #include <cctype>
 #include <fstream>
 #include <iostream>
@@ -73,7 +71,7 @@ namespace qca_stack
 /* Regex */
 
 static const std::regex re_white_space{R"(\s)"};
-static const std::regex re_comment{R"(\[.*\]\s*$)"};
+static const std::regex re_comment{R"(\[.*\]$)"};
 static const std::regex re_layer_separator{R"([= *]+\s*$)"};
 static const std::regex re_cell_definition_id{R"((\w)\:$)"};              // group 1 is the id
 static const std::regex re_cell_definition_label{R"(-label=\"(.*)\"$)"};  // group 1 is the label
@@ -106,14 +104,14 @@ class read_fqca_layout_impl
             const auto substituted_line = std::regex_replace(line, qca_stack::re_white_space, "");
             std::cout << fmt::format("substituted line {}: '{}'", line_number, substituted_line) << std::endl;
 
-            // skip empty lines (trimmed first to remove whitespace)
-            if (!substituted_line.empty())
+            // skip empty lines
+            if (!line.empty())
             {
                 // are we currently parsing the layout definition...
                 if (parsing_status == fqca_section::LAYOUT_DEFINITION)
                 {
                     // if line is a comment
-                    if (std::regex_match(line, qca_stack::re_comment))
+                    if (std::regex_match(substituted_line, qca_stack::re_comment))
                     {
                         continue;
                     }
@@ -150,69 +148,73 @@ class read_fqca_layout_impl
                 // ... or the cell definition?
                 else if (parsing_status == fqca_section::CELL_DEFINITION)
                 {
-                    // if line indicates a new cell id
-                    if (std::smatch sm; std::regex_match(line, sm, qca_stack::re_cell_definition_id))
+                    // skip empty substituted lines
+                    if (!substituted_line.empty())
                     {
-                        // the cell id is captured in the first regex group, whose result is a single character
-                        const auto cell_id = sm.str(1)[0];
-
-                        if (auto it = cell_label_map.find(cell_id); it != cell_label_map.cend())
+                        // if line indicates a new cell id
+                        if (std::smatch sm; std::regex_match(substituted_line, sm, qca_stack::re_cell_definition_id))
                         {
-                            current_labeled_cell = it->second;
+                            // the cell id is captured in the first regex group, whose result is a single character
+                            const auto cell_id = sm.str(1)[0];
+
+                            if (auto it = cell_label_map.find(cell_id); it != cell_label_map.cend())
+                            {
+                                current_labeled_cell = it->second;
+                            }
+                            else
+                            {
+                                std::cout << "undefined cell label" << std::endl;
+                                std::cout << fmt::format("line {}: '{}'", line_number, substituted_line) << std::endl;
+                                throw undefined_cell_label_exception(cell_id);
+                            }
+                        }
+                        // if line indicates a primary input flag
+                        else if (substituted_line == qca_stack::cell_definition_input)
+                        {
+                            lyt.assign_cell_type(current_labeled_cell, technology<Lyt>::cell_type::INPUT);
+                        }
+                        // if line indicates a primary output flag
+                        else if (substituted_line == qca_stack::cell_definition_output)
+                        {
+                            lyt.assign_cell_type(current_labeled_cell, technology<Lyt>::cell_type::OUTPUT);
+                        }
+                        // if line indicates a cell label
+                        else if (std::regex_match(substituted_line, sm, qca_stack::re_cell_definition_label))
+                        {
+                            // the cell label is captured in the first regex group
+                            const auto cell_label = sm.str(1);
+
+                            lyt.assign_cell_name(current_labeled_cell, cell_label);
+                        }
+                        // if line indicates a cell label
+                        else if (std::regex_match(substituted_line, sm, qca_stack::re_cell_definition_clock))
+                        {
+                            // the clock number is captured in the first regex group, whose result is a single number
+                            const auto clock_number_char = sm.str(1)[0];
+
+                            lyt.assign_clock_number(current_labeled_cell, to_clock_number(clock_number_char));
+                        }
+                        // if line indicates a propagate flag
+                        else if (substituted_line == qca_stack::cell_definition_propagate)
+                        {
+                            // 'propagate' is not supported
+                        }
+                        // if line indicates a number definition
+                        else if (std::regex_match(substituted_line, sm, qca_stack::re_cell_definition_number))
+                        {
+                            // 'number' is not supported
+                        }
+                        // if line indicates an offset definition
+                        else if (std::regex_match(substituted_line, sm, qca_stack::re_cell_definition_offset))
+                        {
+                            // 'offset' is not supported
                         }
                         else
                         {
-                            std::cout << "undefined cell label" << std::endl;
-                            std::cout << fmt::format("line {}: '{}'", line_number, line) << std::endl;
-                            throw undefined_cell_label_exception(cell_id);
+                            std::cout << "undefined cell definition" << std::endl;
+                            std::cout << fmt::format("line {}: '{}'", line_number, substituted_line) << std::endl;
+                            throw unrecognized_cell_definition_exception(line_number);
                         }
-                    }
-                    // if line indicates a primary input flag
-                    else if (line == qca_stack::cell_definition_input)
-                    {
-                        lyt.assign_cell_type(current_labeled_cell, technology<Lyt>::cell_type::INPUT);
-                    }
-                    // if line indicates a primary output flag
-                    else if (line == qca_stack::cell_definition_output)
-                    {
-                        lyt.assign_cell_type(current_labeled_cell, technology<Lyt>::cell_type::OUTPUT);
-                    }
-                    // if line indicates a cell label
-                    else if (std::regex_match(line, sm, qca_stack::re_cell_definition_label))
-                    {
-                        // the cell label is captured in the first regex group
-                        const auto cell_label = sm.str(1);
-
-                        lyt.assign_cell_name(current_labeled_cell, cell_label);
-                    }
-                    // if line indicates a cell label
-                    else if (std::regex_match(line, sm, qca_stack::re_cell_definition_clock))
-                    {
-                        // the clock number is captured in the first regex group, whose result is a single number
-                        const auto clock_number_char = sm.str(1)[0];
-
-                        lyt.assign_clock_number(current_labeled_cell, to_clock_number(clock_number_char));
-                    }
-                    // if line indicates a propagate flag
-                    else if (line == qca_stack::cell_definition_propagate)
-                    {
-                        // 'propagate' is not supported
-                    }
-                    // if line indicates a number definition
-                    else if (std::regex_match(line, sm, qca_stack::re_cell_definition_number))
-                    {
-                        // 'number' is not supported
-                    }
-                    // if line indicates an offset definition
-                    else if (std::regex_match(line, sm, qca_stack::re_cell_definition_offset))
-                    {
-                        // 'offset' is not supported
-                    }
-                    else
-                    {
-                        std::cout << "undefined cell definition" << std::endl;
-                        std::cout << fmt::format("line {}: '{}'", line_number, line) << std::endl;
-                        throw unrecognized_cell_definition_exception(line_number);
                     }
                 }
             }

--- a/include/fiction/io/read_fqca_layout.hpp
+++ b/include/fiction/io/read_fqca_layout.hpp
@@ -8,6 +8,8 @@
 #include "../technology/cell_technologies.hpp"
 #include "../traits.hpp"
 
+#include <lorina/detail/utils.hpp>
+
 #include <cctype>
 #include <fstream>
 #include <iostream>
@@ -100,8 +102,8 @@ class read_fqca_layout_impl
         uint64_t line_number{0ull};
         for (std::string line{}; std::getline(is, line); ++line_number)
         {
-            // skip empty lines
-            if (!line.empty())
+            // skip empty lines (trimmed first to remove whitespace)
+            if (!lorina::detail::trim_copy(line).empty())
             {
                 // are we currently parsing the layout definition...
                 if (parsing_status == fqca_section::LAYOUT_DEFINITION)

--- a/include/fiction/io/read_fqca_layout.hpp
+++ b/include/fiction/io/read_fqca_layout.hpp
@@ -10,6 +10,7 @@
 
 #include <cctype>
 #include <fstream>
+#include <iostream>
 #include <istream>
 #include <regex>
 #include <sstream>

--- a/include/fiction/io/read_fqca_layout.hpp
+++ b/include/fiction/io/read_fqca_layout.hpp
@@ -72,7 +72,7 @@ namespace qca_stack
 
 /* Regex */
 
-static const std::regex re_white_space{R"(\s*)"};
+static const std::regex re_white_space{R"(\s)"};
 static const std::regex re_comment{R"(\[.*\]\s*$)"};
 static const std::regex re_layer_separator{R"([= *]+\s*$)"};
 static const std::regex re_cell_definition_id{R"((\w)\:$)"};              // group 1 is the id

--- a/include/fiction/io/read_fqca_layout.hpp
+++ b/include/fiction/io/read_fqca_layout.hpp
@@ -102,8 +102,12 @@ class read_fqca_layout_impl
         uint64_t line_number{1ull};
         for (std::string line{}; std::getline(is, line); ++line_number)
         {
+            // remove all white space from the line to make regex matching easier and more robust
+            const auto substituted_line = std::regex_replace(line, qca_stack::re_white_space, "");
+            std::cout << fmt::format("substituted line {}: '{}'", line_number, substituted_line) << std::endl;
+
             // skip empty lines (trimmed first to remove whitespace)
-            if (!(lorina::detail::trim_copy(line).empty()))
+            if (!substituted_line.empty())
             {
                 // are we currently parsing the layout definition...
                 if (parsing_status == fqca_section::LAYOUT_DEFINITION)
@@ -125,7 +129,7 @@ class read_fqca_layout_impl
                     else
                     {
                         // section delimiter
-                        if (line == "$")
+                        if (substituted_line == "$")
                         {
                             parsing_status = fqca_section::CELL_DEFINITION;
                         }
@@ -146,76 +150,69 @@ class read_fqca_layout_impl
                 // ... or the cell definition?
                 else if (parsing_status == fqca_section::CELL_DEFINITION)
                 {
-                    // remove all white space from the line to make regex matching easier and more robust
-                    line = std::regex_replace(line, qca_stack::re_white_space, "");
-
-                    // still skip empty lines
-                    if (!line.empty())
+                    // if line indicates a new cell id
+                    if (std::smatch sm; std::regex_match(line, sm, qca_stack::re_cell_definition_id))
                     {
-                        // if line indicates a new cell id
-                        if (std::smatch sm; std::regex_match(line, sm, qca_stack::re_cell_definition_id))
-                        {
-                            // the cell id is captured in the first regex group, whose result is a single character
-                            const auto cell_id = sm.str(1)[0];
+                        // the cell id is captured in the first regex group, whose result is a single character
+                        const auto cell_id = sm.str(1)[0];
 
-                            if (auto it = cell_label_map.find(cell_id); it != cell_label_map.cend())
-                            {
-                                current_labeled_cell = it->second;
-                            }
-                            else
-                            {
-                                std::cout << "undefined cell label" << std::endl;
-                                std::cout << fmt::format("line {}: '{}'", line_number, line) << std::endl;
-                                throw undefined_cell_label_exception(cell_id);
-                            }
-                        }
-                        // if line indicates a primary input flag
-                        else if (line == qca_stack::cell_definition_input)
+                        if (auto it = cell_label_map.find(cell_id); it != cell_label_map.cend())
                         {
-                            lyt.assign_cell_type(current_labeled_cell, technology<Lyt>::cell_type::INPUT);
-                        }
-                        // if line indicates a primary output flag
-                        else if (line == qca_stack::cell_definition_output)
-                        {
-                            lyt.assign_cell_type(current_labeled_cell, technology<Lyt>::cell_type::OUTPUT);
-                        }
-                        // if line indicates a cell label
-                        else if (std::regex_match(line, sm, qca_stack::re_cell_definition_label))
-                        {
-                            // the cell label is captured in the first regex group
-                            const auto cell_label = sm.str(1);
-
-                            lyt.assign_cell_name(current_labeled_cell, cell_label);
-                        }
-                        // if line indicates a cell label
-                        else if (std::regex_match(line, sm, qca_stack::re_cell_definition_clock))
-                        {
-                            // the clock number is captured in the first regex group, whose result is a single number
-                            const auto clock_number_char = sm.str(1)[0];
-
-                            lyt.assign_clock_number(current_labeled_cell, to_clock_number(clock_number_char));
-                        }
-                        // if line indicates a propagate flag
-                        else if (line == qca_stack::cell_definition_propagate)
-                        {
-                            // 'propagate' is not supported
-                        }
-                        // if line indicates a number definition
-                        else if (std::regex_match(line, sm, qca_stack::re_cell_definition_number))
-                        {
-                            // 'number' is not supported
-                        }
-                        // if line indicates an offset definition
-                        else if (std::regex_match(line, sm, qca_stack::re_cell_definition_offset))
-                        {
-                            // 'offset' is not supported
+                            current_labeled_cell = it->second;
                         }
                         else
                         {
-                            std::cout << "undefined cell definition" << std::endl;
+                            std::cout << "undefined cell label" << std::endl;
                             std::cout << fmt::format("line {}: '{}'", line_number, line) << std::endl;
-                            throw unrecognized_cell_definition_exception(line_number);
+                            throw undefined_cell_label_exception(cell_id);
                         }
+                    }
+                    // if line indicates a primary input flag
+                    else if (line == qca_stack::cell_definition_input)
+                    {
+                        lyt.assign_cell_type(current_labeled_cell, technology<Lyt>::cell_type::INPUT);
+                    }
+                    // if line indicates a primary output flag
+                    else if (line == qca_stack::cell_definition_output)
+                    {
+                        lyt.assign_cell_type(current_labeled_cell, technology<Lyt>::cell_type::OUTPUT);
+                    }
+                    // if line indicates a cell label
+                    else if (std::regex_match(line, sm, qca_stack::re_cell_definition_label))
+                    {
+                        // the cell label is captured in the first regex group
+                        const auto cell_label = sm.str(1);
+
+                        lyt.assign_cell_name(current_labeled_cell, cell_label);
+                    }
+                    // if line indicates a cell label
+                    else if (std::regex_match(line, sm, qca_stack::re_cell_definition_clock))
+                    {
+                        // the clock number is captured in the first regex group, whose result is a single number
+                        const auto clock_number_char = sm.str(1)[0];
+
+                        lyt.assign_clock_number(current_labeled_cell, to_clock_number(clock_number_char));
+                    }
+                    // if line indicates a propagate flag
+                    else if (line == qca_stack::cell_definition_propagate)
+                    {
+                        // 'propagate' is not supported
+                    }
+                    // if line indicates a number definition
+                    else if (std::regex_match(line, sm, qca_stack::re_cell_definition_number))
+                    {
+                        // 'number' is not supported
+                    }
+                    // if line indicates an offset definition
+                    else if (std::regex_match(line, sm, qca_stack::re_cell_definition_offset))
+                    {
+                        // 'offset' is not supported
+                    }
+                    else
+                    {
+                        std::cout << "undefined cell definition" << std::endl;
+                        std::cout << fmt::format("line {}: '{}'", line_number, line) << std::endl;
+                        throw unrecognized_cell_definition_exception(line_number);
                     }
                 }
             }

--- a/include/fiction/io/read_fqca_layout.hpp
+++ b/include/fiction/io/read_fqca_layout.hpp
@@ -158,6 +158,8 @@ class read_fqca_layout_impl
                         }
                         else
                         {
+                            std::cout << "undefined cell label" << std::endl;
+                            std::cout << "line: " << line << std::endl;
                             throw undefined_cell_label_exception(cell_id);
                         }
                     }
@@ -204,6 +206,8 @@ class read_fqca_layout_impl
                     }
                     else
                     {
+                        std::cout << "undefined cell definition" << std::endl;
+                        std::cout << "line: " << line << std::endl;
                         throw unrecognized_cell_definition_exception(line_number);
                     }
                 }
@@ -278,6 +282,8 @@ class read_fqca_layout_impl
         }
         else
         {
+            std::cout << "unsupported character" << std::endl;
+            std::cout << "char: " << c << std::endl;
             throw unsupported_character_exception(c);
         }
 


### PR DESCRIPTION
`std::regex_replace` behaves differently under macOS compared to Windows and Linux. This PR fixes an issue with string substitution.