### PR TITLE
:rotating_light: Make sure the Bestagon experiment is not compiled if Z3 is not found

### DIFF
--- a/experiments/bestagon/bestagon.cpp
+++ b/experiments/bestagon/bestagon.cpp
@@ -2,6 +2,8 @@
 // Created by marcel on 16.11.21.
 //
 
+#if (FICTION_Z3_SOLVER)
+
 #include "fiction_experiments.hpp"
 
 #include <fiction/algorithms/physical_design/apply_gate_library.hpp>  // layout conversion to cell-level
@@ -176,3 +178,5 @@ int main()
 
     return 0;
 }
+
+#endif  // FICTION_Z3_SOLVER


### PR DESCRIPTION
If Z3 was not enabled, attempting to build the Bestagon experiment lead to a compilation error. This has been fixed.