### PR TITLE
Update GitHub Action CI Runners and Dependencies

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Build
         working-directory: ${{github.workspace}}/build
 
-        run: cmake --build . --config $BUILD_TYPE -j2
+        run: cmake --build . --config $BUILD_TYPE
 
       - name: Test
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ defaults:
     shell: bash
 
 env:
-  Z3_GIT_TAG: z3-4.8.12
+  Z3_GIT_TAG: z3-4.10.0
 
 jobs:
   build_and_test:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,20 +32,6 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.9.x'
-
-      - name: Install pip packages
-        uses: BSFishy/pip-action@v1
-        with:
-          packages: |
-            wheel
-            graphviz
-            python-sat==0.1.6.dev6
-            wrapt_timeout_decorator
-
       - name: Clone Repository
         uses: actions/checkout@v3
         with:
@@ -72,7 +58,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
 
-        run: cmake ${{github.workspace}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_Z3_SEARCH_PATHS=${{github.workspace}}/z3lib -DFICTION_ENABLE_MUGEN=ON -DFICTION_PROGRESS_BARS=OFF -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
+        run: cmake ${{github.workspace}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_Z3_SEARCH_PATHS=${{github.workspace}}/z3lib -DFICTION_PROGRESS_BARS=OFF -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,10 +23,19 @@ jobs:
             ccompiler: gcc
           - os: macos-11
             compiler: g++-9
+            build_type: Debug
+          - os: macos-11
+            compiler: g++-9
+            build_type: Release
             ccompiler: gcc
           - os: macos-11
             compiler: g++-10
             ccompiler: gcc
+            build_type: Debug
+          - os: macos-11
+            compiler: g++-10
+            ccompiler: gcc
+            build_type: Release
 
     name: ${{matrix.os}} with ${{matrix.compiler}} (${{matrix.build_type}} mode)
     runs-on: ${{matrix.os}}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,16 +13,20 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [ macos-10.15 ]  # macos-11 when supported
-        compiler: [ g++-9, g++-10, clang++ ]  # clang++12
+        os: [ macos-11, macos-12 ]
+        compiler: [ g++-11, clang++ ]
         build_type: [ Debug, Release ]
         include:
-          - compiler: g++-9
-            ccompiler: gcc
-          - compiler: g++-10
-            ccompiler: gcc
           - compiler: clang++
             ccompiler: clang
+          - compiler: g++-11
+            ccompiler: gcc
+          - os: macos-11
+            compiler: g++-9
+            ccompiler: gcc
+          - os: macos-11
+          - compiler: g++-10
+            ccompiler: gcc
 
     name: ${{matrix.os}} with ${{matrix.compiler}} (${{matrix.build_type}} mode)
     runs-on: ${{matrix.os}}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,6 +41,7 @@ jobs:
         uses: BSFishy/pip-action@v1
         with:
           packages: |
+            wheel
             graphviz
             python-sat==0.1.6.dev6
             wrapt_timeout_decorator

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,7 +25,7 @@ jobs:
             compiler: g++-9
             ccompiler: gcc
           - os: macos-11
-          - compiler: g++-10
+            compiler: g++-10
             ccompiler: gcc
 
     name: ${{matrix.os}} with ${{matrix.compiler}} (${{matrix.build_type}} mode)

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,7 +7,7 @@ defaults:
     shell: bash
 
 env:
-  Z3_GIT_TAG: z3-4.8.12
+  Z3_GIT_TAG: z3-4.10.0
 
 jobs:
   build_and_test:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -21,6 +21,8 @@ jobs:
             compiler: clang++-11
           - os: ubuntu-18.04
             compiler: clang++-12
+          - os: ubuntu-22.04
+            compiler: clang++-10
         include:
           - os: ubuntu-18.04
             compiler: clang++-9

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -24,8 +24,13 @@ jobs:
         include:
           - os: ubuntu-18.04
             compiler: clang++-9
+            build_type: Debug
+          - os: ubuntu-18.04
+            compiler: clang++-9
+            build_type: Release
           - os: ubuntu-20.04
             compiler: g++-10
+            build_type: Release
             cppstandard: -DFICTION_CXX_STANDARD=20
             cppname: C++20
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,8 +13,8 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-18.04 ]
-        compiler: [ g++-9, g++-10, clang++-9, clang++-10 ]
+        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
+        compiler: [ g++-9, g++-10, clang++-10, clang++-11, clang++-12 ]
         build_type: [ Debug, Release ]
         include:
           - os: ubuntu-20.04

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -46,15 +46,15 @@ jobs:
         with:
           python-version: '3.9.x'
 
-      - name: Install pip packages
-        uses: BSFishy/pip-action@v1
-        with:
-          requirements: ${{github.workspace}}/libs/mugen/requirements.txt
-
       - name: Clone Repository
         uses: actions/checkout@v3
         with:
           submodules: recursive
+
+      - name: Install pip packages
+        uses: BSFishy/pip-action@v1
+        with:
+          requirements: ${{github.workspace}}/libs/mugen/requirements.txt
 
       - name: Cache Z3 Solver
         id: cache-z3-solver

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -49,10 +49,7 @@ jobs:
       - name: Install pip packages
         uses: BSFishy/pip-action@v1
         with:
-          packages: |
-            graphviz
-            python-sat==0.1.6.dev6
-            wrapt_timeout_decorator
+          requirements: ${{github.workspace}}/libs/mugen/requirements.txt
 
       - name: Clone Repository
         uses: actions/checkout@v3

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -16,7 +16,14 @@ jobs:
         os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
         compiler: [ g++-9, g++-10, clang++-10, clang++-11, clang++-12 ]
         build_type: [ Debug, Release ]
+        exclude:
+          - os: ubuntu-18.04
+            compiler: clang++-11
+          - os: ubuntu-18.04
+            compiler: clang++-12
         include:
+          - os: ubuntu-18.04
+            compiler: clang++-9
           - os: ubuntu-20.04
             compiler: g++-10
             cppstandard: -DFICTION_CXX_STANDARD=20

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,12 +13,14 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [ windows-2019 ]
+        os: [ windows-2019, windows-2022 ]
         toolset: [ v142, ClangCL ]
         build_type: [ Debug, Release ]
         include:
           - os: windows-2019
             env: "Visual Studio 16 2019"
+          - os: windows-2022
+            env: "Visual Studio 17 2022"
 
     name: ${{matrix.os}} with ${{matrix.env}} and ${{matrix.toolset}} toolset (${{matrix.build_type}} mode)
     runs-on: ${{matrix.os}}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,11 +26,6 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.9.x'
-
       - name: Clone Repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ defaults:
     shell: pwsh  # use pwsh as directory handling does not seem to work with bash
 
 env:
-  Z3_GIT_TAG: z3-4.8.12
+  Z3_GIT_TAG: z3-4.10.0
 
 jobs:
   build_and_test:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -101,7 +101,7 @@ It has some further Python dependencies that can be installed via ``pip3``::
     pip3 install python-sat==0.1.6.dev6 wrapt_timeout_decorator graphviz
 
 The Python3 integration is experimental and may cause issues on some systems. It is currently not available on Windows
-due to issues with ``python-sat``. Mugen requires at least Python 3.7!
+and some macOS versions due to issues with ``python-sat``. Mugen requires at least Python 3.7!
 
 Finally, before building *fiction*, pass ``-DFICTION_ENABLE_MUGEN=ON`` to the ``cmake`` call.
 

--- a/libs/mugen/requirements.txt
+++ b/libs/mugen/requirements.txt
@@ -1,0 +1,3 @@
+python-sat==0.1.6.dev6
+wrapt_timeout_decorator
+graphviz


### PR DESCRIPTION
This PR updates the GitHub Action CI scripts to access the latest OS and tool versions for all builds. This is particularly important for the macOS 10.15 runners which were already deprecated and recently saw a scheduled brownout. 