### PR TITLE
:green_heart: Upgraded toolset to v143 for Visual Studio 2022 CI builds

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,13 +14,18 @@ jobs:
     strategy:
       matrix:
         os: [ windows-2019, windows-2022 ]
-        toolset: [ v142, ClangCL ]
+        toolset: [ v142, v143, ClangCL ]
         build_type: [ Debug, Release ]
         include:
           - os: windows-2019
             env: "Visual Studio 16 2019"
           - os: windows-2022
             env: "Visual Studio 17 2022"
+        exclude:
+          - os: windows-2019
+            toolset: v143
+          - os: windows-2022
+            toolset: v142
 
     name: ${{matrix.os}} with ${{matrix.env}} and ${{matrix.toolset}} toolset (${{matrix.build_type}} mode)
     runs-on: ${{matrix.os}}
@@ -44,7 +49,7 @@ jobs:
         shell: bash
         run: |
           git clone --branch $Z3_GIT_TAG --depth 1 https://github.com/Z3Prover/z3.git
-          CC=clang CXX=clang++ cmake -S z3 -B z3\build -DCMAKE_INSTALL_PREFIX=z3lib -DZ3_BUILD_LIBZ3_SHARED=OFF -DZ3_BUILD_TEST_EXECUTABLES=OFF -DZ3_ENABLE_EXAMPLE_TARGETS=OFF
+          cmake -S z3 -B z3\build -G "${{matrix.env}}" -A x64 -DCMAKE_INSTALL_PREFIX=z3lib -DZ3_BUILD_LIBZ3_SHARED=OFF -DZ3_BUILD_TEST_EXECUTABLES=OFF -DZ3_ENABLE_EXAMPLE_TARGETS=OFF
           cmake --build z3\build --config ${{matrix.build_type}} -j2 --target install
 
       - name: Create Build Environment


### PR DESCRIPTION
This fixes Z3 linking on Windows CI with VS 2022.