### PR TITLE
:construction_worker: Enabled automatic linking with TBB when compiling with GCC to enable parallel STL algorithms

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -30,8 +30,8 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - name: Install the respective compiler
-        run: sudo apt-get update && sudo apt-get install -yq ${{matrix.compiler}}
+      - name: Install libraries and the respective compiler
+        run: sudo apt-get update && sudo apt-get install -yq libtbb-dev ${{matrix.compiler}}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ project(fiction
         LANGUAGES CXX
         VERSION 0.4.0)
 
-include(cmake/StandardProjectSettings.cmake)
-include(cmake/PreventInSourceBuilds.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/StandardProjectSettings.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/PreventInSourceBuilds.cmake)
 
 # Set C++ standard; at least C++17 is required
 set(FICTION_CXX_STANDARD "17" CACHE STRING "C++ standard")
@@ -28,18 +28,18 @@ endif ()
 add_library(project_warnings INTERFACE)
 
 # Enable cache system
-include(cmake/Cache.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Cache.cmake)
 
 # Standard compiler warnings
-include(cmake/CompilerWarnings.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CompilerWarnings.cmake)
 set_project_warnings(project_warnings)
 
 # Sanitizer options if supported by compiler
-include(cmake/Sanitizers.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Sanitizers.cmake)
 enable_sanitizers(project_options)
 
 # Allow for static analysis options
-include(cmake/StaticAnalyzers.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/StaticAnalyzers.cmake)
 
 # Enable progress bars
 if (NOT WIN32)

--- a/cmake/FindTBB.cmake
+++ b/cmake/FindTBB.cmake
@@ -1,0 +1,303 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 Justus Calvin
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+#
+# FindTBB
+# -------
+#
+# Find TBB include directories and libraries.
+#
+# Usage:
+#
+#  find_package(TBB [major[.minor]] [EXACT]
+#               [QUIET] [REQUIRED]
+#               [[COMPONENTS] [components...]]
+#               [OPTIONAL_COMPONENTS components...])
+#
+# where the allowed components are tbbmalloc and tbb_preview. Users may modify
+# the behavior of this module with the following variables:
+#
+# * TBB_ROOT_DIR          - The base directory the of TBB installation.
+# * TBB_INCLUDE_DIR       - The directory that contains the TBB headers files.
+# * TBB_LIBRARY           - The directory that contains the TBB library files.
+# * TBB_<library>_LIBRARY - The path of the TBB the corresponding TBB library.
+#                           These libraries, if specified, override the
+#                           corresponding library search results, where <library>
+#                           may be tbb, tbb_debug, tbbmalloc, tbbmalloc_debug,
+#                           tbb_preview, or tbb_preview_debug.
+# * TBB_USE_DEBUG_BUILD   - The debug version of tbb libraries, if present, will
+#                           be used instead of the release version.
+#
+# Users may modify the behavior of this module with the following environment
+# variables:
+#
+# * TBB_INSTALL_DIR
+# * TBBROOT
+# * LIBRARY_PATH
+#
+# This module will set the following variables:
+#
+# * TBB_FOUND             - Set to false, or undefined, if we haven’t found, or
+#                           don’t want to use TBB.
+# * TBB_<component>_FOUND - If False, optional <component> part of TBB sytem is
+#                           not available.
+# * TBB_VERSION           - The full version string
+# * TBB_VERSION_MAJOR     - The major version
+# * TBB_VERSION_MINOR     - The minor version
+# * TBB_INTERFACE_VERSION - The interface version number defined in
+#                           tbb/tbb_stddef.h.
+# * TBB_<library>_LIBRARY_RELEASE - The path of the TBB release version of
+#                           <library>, where <library> may be tbb, tbb_debug,
+#                           tbbmalloc, tbbmalloc_debug, tbb_preview, or
+#                           tbb_preview_debug.
+# * TBB_<library>_LIBRARY_DEGUG - The path of the TBB release version of
+#                           <library>, where <library> may be tbb, tbb_debug,
+#                           tbbmalloc, tbbmalloc_debug, tbb_preview, or
+#                           tbb_preview_debug.
+#
+# The following varibles should be used to build and link with TBB:
+#
+# * TBB_INCLUDE_DIRS        - The include directory for TBB.
+# * TBB_LIBRARIES           - The libraries to link against to use TBB.
+# * TBB_LIBRARIES_RELEASE   - The release libraries to link against to use TBB.
+# * TBB_LIBRARIES_DEBUG     - The debug libraries to link against to use TBB.
+# * TBB_DEFINITIONS         - Definitions to use when compiling code that uses
+#                             TBB.
+# * TBB_DEFINITIONS_RELEASE - Definitions to use when compiling release code that
+#                             uses TBB.
+# * TBB_DEFINITIONS_DEBUG   - Definitions to use when compiling debug code that
+#                             uses TBB.
+#
+# This module will also create the "tbb" target that may be used when building
+# executables and libraries.
+
+include(FindPackageHandleStandardArgs)
+
+if (NOT TBB_FOUND)
+
+    ##################################
+    # Check the build type
+    ##################################
+
+    if (NOT DEFINED TBB_USE_DEBUG_BUILD)
+        if (CMAKE_BUILD_TYPE MATCHES "(Debug|DEBUG|debug|RelWithDebInfo|RELWITHDEBINFO|relwithdebinfo)")
+            set(TBB_BUILD_TYPE DEBUG)
+        else ()
+            set(TBB_BUILD_TYPE RELEASE)
+        endif ()
+    elseif (TBB_USE_DEBUG_BUILD)
+        set(TBB_BUILD_TYPE DEBUG)
+    else ()
+        set(TBB_BUILD_TYPE RELEASE)
+    endif ()
+
+    ##################################
+    # Set the TBB search directories
+    ##################################
+
+    # Define search paths based on user input and environment variables
+    set(TBB_SEARCH_DIR ${TBB_ROOT_DIR} $ENV{TBB_INSTALL_DIR} $ENV{TBBROOT})
+
+    # Define the search directories based on the current platform
+    if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+        set(TBB_DEFAULT_SEARCH_DIR "C:/Program Files/Intel/TBB"
+                "C:/Program Files (x86)/Intel/TBB")
+
+        # Set the target architecture
+        if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+            set(TBB_ARCHITECTURE "intel64")
+        else ()
+            set(TBB_ARCHITECTURE "ia32")
+        endif ()
+
+        # Set the TBB search library path search suffix based on the version of VC
+        if (WINDOWS_STORE)
+            set(TBB_LIB_PATH_SUFFIX "lib/${TBB_ARCHITECTURE}/vc11_ui")
+        elseif (MSVC14)
+            set(TBB_LIB_PATH_SUFFIX "lib/${TBB_ARCHITECTURE}/vc14")
+        elseif (MSVC12)
+            set(TBB_LIB_PATH_SUFFIX "lib/${TBB_ARCHITECTURE}/vc12")
+        elseif (MSVC11)
+            set(TBB_LIB_PATH_SUFFIX "lib/${TBB_ARCHITECTURE}/vc11")
+        elseif (MSVC10)
+            set(TBB_LIB_PATH_SUFFIX "lib/${TBB_ARCHITECTURE}/vc10")
+        endif ()
+
+        # Add the library path search suffix for the VC independent version of TBB
+        list(APPEND TBB_LIB_PATH_SUFFIX "lib/${TBB_ARCHITECTURE}/vc_mt")
+
+    elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+        # OS X
+        set(TBB_DEFAULT_SEARCH_DIR "/opt/intel/tbb")
+
+        # TODO: Check to see which C++ library is being used by the compiler.
+        if (NOT ${CMAKE_SYSTEM_VERSION} VERSION_LESS 13.0)
+            # The default C++ library on OS X 10.9 and later is libc++
+            set(TBB_LIB_PATH_SUFFIX "lib/libc++" "lib")
+        else ()
+            set(TBB_LIB_PATH_SUFFIX "lib")
+        endif ()
+    elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        # Linux
+        set(TBB_DEFAULT_SEARCH_DIR "/opt/intel/tbb")
+
+        # TODO: Check compiler version to see the suffix should be <arch>/gcc4.1 or
+        #       <arch>/gcc4.1. For now, assume that the compiler is more recent than
+        #       gcc 4.4.x or later.
+        if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+            set(TBB_LIB_PATH_SUFFIX "lib/intel64/gcc4.4")
+        elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^i.86$")
+            set(TBB_LIB_PATH_SUFFIX "lib/ia32/gcc4.4")
+        endif ()
+    endif ()
+
+    ##################################
+    # Find the TBB include dir
+    ##################################
+
+    find_path(TBB_INCLUDE_DIRS tbb/tbb.h
+            HINTS ${TBB_INCLUDE_DIR} ${TBB_SEARCH_DIR}
+            PATHS ${TBB_DEFAULT_SEARCH_DIR}
+            PATH_SUFFIXES include)
+
+    ##################################
+    # Set version strings
+    ##################################
+
+    if (TBB_INCLUDE_DIRS)
+        file(READ "${TBB_INCLUDE_DIRS}/oneapi/tbb/version.h" _tbb_version_file)
+        string(REGEX REPLACE ".*#define TBB_VERSION_MAJOR ([0-9]+).*" "\\1"
+                TBB_VERSION_MAJOR "${_tbb_version_file}")
+        string(REGEX REPLACE ".*#define TBB_VERSION_MINOR ([0-9]+).*" "\\1"
+                TBB_VERSION_MINOR "${_tbb_version_file}")
+        string(REGEX REPLACE ".*#define TBB_INTERFACE_VERSION ([0-9]+).*" "\\1"
+                TBB_INTERFACE_VERSION "${_tbb_version_file}")
+        set(TBB_VERSION "${TBB_VERSION_MAJOR}.${TBB_VERSION_MINOR}")
+    endif ()
+
+    ##################################
+    # Find TBB components
+    ##################################
+
+    if (TBB_VERSION VERSION_LESS 4.3)
+        set(TBB_SEARCH_COMPOMPONENTS tbb_preview tbbmalloc tbb)
+    else ()
+        set(TBB_SEARCH_COMPOMPONENTS tbb_preview tbbmalloc_proxy tbbmalloc tbb)
+    endif ()
+
+    # Find each component
+    foreach (_comp ${TBB_SEARCH_COMPOMPONENTS})
+        if (";${TBB_FIND_COMPONENTS};tbb;" MATCHES ";${_comp};")
+
+            # Search for the libraries
+            find_library(TBB_${_comp}_LIBRARY_RELEASE ${_comp}
+                    HINTS ${TBB_LIBRARY} ${TBB_SEARCH_DIR}
+                    PATHS ${TBB_DEFAULT_SEARCH_DIR} ENV LIBRARY_PATH
+                    PATH_SUFFIXES ${TBB_LIB_PATH_SUFFIX})
+
+            find_library(TBB_${_comp}_LIBRARY_DEBUG ${_comp}_debug
+                    HINTS ${TBB_LIBRARY} ${TBB_SEARCH_DIR}
+                    PATHS ${TBB_DEFAULT_SEARCH_DIR} ENV LIBRARY_PATH
+                    PATH_SUFFIXES ${TBB_LIB_PATH_SUFFIX})
+
+            if (TBB_${_comp}_LIBRARY_DEBUG)
+                list(APPEND TBB_LIBRARIES_DEBUG "${TBB_${_comp}_LIBRARY_DEBUG}")
+            endif ()
+            if (TBB_${_comp}_LIBRARY_RELEASE)
+                list(APPEND TBB_LIBRARIES_RELEASE "${TBB_${_comp}_LIBRARY_RELEASE}")
+            endif ()
+            if (TBB_${_comp}_LIBRARY_${TBB_BUILD_TYPE} AND NOT TBB_${_comp}_LIBRARY)
+                set(TBB_${_comp}_LIBRARY "${TBB_${_comp}_LIBRARY_${TBB_BUILD_TYPE}}")
+            endif ()
+
+            if (TBB_${_comp}_LIBRARY AND EXISTS "${TBB_${_comp}_LIBRARY}")
+                set(TBB_${_comp}_FOUND TRUE)
+            else ()
+                set(TBB_${_comp}_FOUND FALSE)
+            endif ()
+
+            # Mark internal variables as advanced
+            mark_as_advanced(TBB_${_comp}_LIBRARY_RELEASE)
+            mark_as_advanced(TBB_${_comp}_LIBRARY_DEBUG)
+            mark_as_advanced(TBB_${_comp}_LIBRARY)
+
+        endif ()
+    endforeach ()
+
+    ##################################
+    # Set compile flags and libraries
+    ##################################
+
+    set(TBB_DEFINITIONS_RELEASE "")
+    set(TBB_DEFINITIONS_DEBUG "-DTBB_USE_DEBUG=1")
+
+    if (TBB_LIBRARIES_${TBB_BUILD_TYPE})
+        set(TBB_DEFINITIONS "${TBB_DEFINITIONS_${TBB_BUILD_TYPE}}")
+        set(TBB_LIBRARIES "${TBB_LIBRARIES_${TBB_BUILD_TYPE}}")
+    elseif (TBB_LIBRARIES_RELEASE)
+        set(TBB_DEFINITIONS "${TBB_DEFINITIONS_RELEASE}")
+        set(TBB_LIBRARIES "${TBB_LIBRARIES_RELEASE}")
+    elseif (TBB_LIBRARIES_DEBUG)
+        set(TBB_DEFINITIONS "${TBB_DEFINITIONS_DEBUG}")
+        set(TBB_LIBRARIES "${TBB_LIBRARIES_DEBUG}")
+    endif ()
+
+    find_package_handle_standard_args(TBB
+            REQUIRED_VARS TBB_INCLUDE_DIRS TBB_LIBRARIES
+            HANDLE_COMPONENTS
+            VERSION_VAR TBB_VERSION)
+
+    ##################################
+    # Create targets
+    ##################################
+
+    if (NOT CMAKE_VERSION VERSION_LESS 3.0 AND TBB_FOUND)
+        add_library(tbb SHARED IMPORTED)
+        set_target_properties(tbb PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES ${TBB_INCLUDE_DIRS}
+                IMPORTED_LOCATION ${TBB_LIBRARIES})
+        if (TBB_LIBRARIES_RELEASE AND TBB_LIBRARIES_DEBUG)
+            set_target_properties(tbb PROPERTIES
+                    INTERFACE_COMPILE_DEFINITIONS "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:TBB_USE_DEBUG=1>"
+                    IMPORTED_LOCATION_DEBUG ${TBB_LIBRARIES_DEBUG}
+                    IMPORTED_LOCATION_RELWITHDEBINFO ${TBB_LIBRARIES_DEBUG}
+                    IMPORTED_LOCATION_RELEASE ${TBB_LIBRARIES_RELEASE}
+                    IMPORTED_LOCATION_MINSIZEREL ${TBB_LIBRARIES_RELEASE}
+                    )
+        elseif (TBB_LIBRARIES_RELEASE)
+            set_target_properties(tbb PROPERTIES IMPORTED_LOCATION ${TBB_LIBRARIES_RELEASE})
+        else ()
+            set_target_properties(tbb PROPERTIES
+                    INTERFACE_COMPILE_DEFINITIONS "${TBB_DEFINITIONS_DEBUG}"
+                    IMPORTED_LOCATION ${TBB_LIBRARIES_DEBUG}
+                    )
+        endif ()
+    endif ()
+
+    mark_as_advanced(TBB_INCLUDE_DIRS TBB_LIBRARIES)
+
+    unset(TBB_ARCHITECTURE)
+    unset(TBB_BUILD_TYPE)
+    unset(TBB_LIB_PATH_SUFFIX)
+    unset(TBB_DEFAULT_SEARCH_DIR)
+
+endif ()

--- a/cmake/FindTBB.cmake
+++ b/cmake/FindTBB.cmake
@@ -1,303 +1,430 @@
-# The MIT License (MIT)
+# - Find ThreadingBuildingBlocks include dirs and libraries
+# Use this module by invoking find_package with the form:
+#  find_package(TBB
+#    [REQUIRED]             # Fail with error if TBB is not found
+#    )                      #
+# Once done, this will define
 #
-# Copyright (c) 2015 Justus Calvin
+#  TBB_FOUND - system has TBB
+#  TBB_INCLUDE_DIRS - the TBB include directories
+#  TBB_LIBRARIES - TBB libraries to be lined, doesn't include malloc or
+#                  malloc proxy
+#  TBB::tbb - imported target for the TBB library
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
+#  TBB_VERSION_MAJOR - Major Product Version Number
+#  TBB_VERSION_MINOR - Minor Product Version Number
+#  TBB_INTERFACE_VERSION - Engineering Focused Version Number
+#  TBB_COMPATIBLE_INTERFACE_VERSION - The oldest major interface version
+#                                     still supported. This uses the engineering
+#                                     focused interface version numbers.
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+#  TBB_MALLOC_FOUND - system has TBB malloc library
+#  TBB_MALLOC_INCLUDE_DIRS - the TBB malloc include directories
+#  TBB_MALLOC_LIBRARIES - The TBB malloc libraries to be lined
+#  TBB::malloc - imported target for the TBB malloc library
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+#  TBB_MALLOC_PROXY_FOUND - system has TBB malloc proxy library
+#  TBB_MALLOC_PROXY_INCLUDE_DIRS = the TBB malloc proxy include directories
+#  TBB_MALLOC_PROXY_LIBRARIES - The TBB malloc proxy libraries to be lined
+#  TBB::malloc_proxy - imported target for the TBB malloc proxy library
+#
+#
+# This module reads hints about search locations from variables:
+#  ENV TBB_ARCH_PLATFORM - for eg. set it to "mic" for Xeon Phi builds
+#  ENV TBB_ROOT or just TBB_ROOT - root directory of tbb installation
+#  ENV TBB_BUILD_PREFIX - specifies the build prefix for user built tbb
+#                         libraries. Should be specified with ENV TBB_ROOT
+#                         and optionally...
+#  ENV TBB_BUILD_DIR - if build directory is different than ${TBB_ROOT}/build
+#
+#
+# Modified by Robert Maynard from the original OGRE source
+#
+#-------------------------------------------------------------------
+# This file is part of the CMake build system for OGRE
+#     (Object-oriented Graphics Rendering Engine)
+# For the latest info, see http://www.ogre3d.org/
+#
+# The contents of this file are placed in the public domain. Feel
+# free to make use of it in any way you like.
+#-------------------------------------------------------------------
+#
+#=============================================================================
+# Copyright 2010-2012 Kitware, Inc.
+# Copyright 2012      Rolf Eike Beer <eike@sf-mail.de>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
 
-#
-# FindTBB
-# -------
-#
-# Find TBB include directories and libraries.
-#
-# Usage:
-#
-#  find_package(TBB [major[.minor]] [EXACT]
-#               [QUIET] [REQUIRED]
-#               [[COMPONENTS] [components...]]
-#               [OPTIONAL_COMPONENTS components...])
-#
-# where the allowed components are tbbmalloc and tbb_preview. Users may modify
-# the behavior of this module with the following variables:
-#
-# * TBB_ROOT_DIR          - The base directory the of TBB installation.
-# * TBB_INCLUDE_DIR       - The directory that contains the TBB headers files.
-# * TBB_LIBRARY           - The directory that contains the TBB library files.
-# * TBB_<library>_LIBRARY - The path of the TBB the corresponding TBB library.
-#                           These libraries, if specified, override the
-#                           corresponding library search results, where <library>
-#                           may be tbb, tbb_debug, tbbmalloc, tbbmalloc_debug,
-#                           tbb_preview, or tbb_preview_debug.
-# * TBB_USE_DEBUG_BUILD   - The debug version of tbb libraries, if present, will
-#                           be used instead of the release version.
-#
-# Users may modify the behavior of this module with the following environment
-# variables:
-#
-# * TBB_INSTALL_DIR
-# * TBBROOT
-# * LIBRARY_PATH
-#
-# This module will set the following variables:
-#
-# * TBB_FOUND             - Set to false, or undefined, if we haven’t found, or
-#                           don’t want to use TBB.
-# * TBB_<component>_FOUND - If False, optional <component> part of TBB sytem is
-#                           not available.
-# * TBB_VERSION           - The full version string
-# * TBB_VERSION_MAJOR     - The major version
-# * TBB_VERSION_MINOR     - The minor version
-# * TBB_INTERFACE_VERSION - The interface version number defined in
-#                           tbb/tbb_stddef.h.
-# * TBB_<library>_LIBRARY_RELEASE - The path of the TBB release version of
-#                           <library>, where <library> may be tbb, tbb_debug,
-#                           tbbmalloc, tbbmalloc_debug, tbb_preview, or
-#                           tbb_preview_debug.
-# * TBB_<library>_LIBRARY_DEGUG - The path of the TBB release version of
-#                           <library>, where <library> may be tbb, tbb_debug,
-#                           tbbmalloc, tbbmalloc_debug, tbb_preview, or
-#                           tbb_preview_debug.
-#
-# The following varibles should be used to build and link with TBB:
-#
-# * TBB_INCLUDE_DIRS        - The include directory for TBB.
-# * TBB_LIBRARIES           - The libraries to link against to use TBB.
-# * TBB_LIBRARIES_RELEASE   - The release libraries to link against to use TBB.
-# * TBB_LIBRARIES_DEBUG     - The debug libraries to link against to use TBB.
-# * TBB_DEFINITIONS         - Definitions to use when compiling code that uses
-#                             TBB.
-# * TBB_DEFINITIONS_RELEASE - Definitions to use when compiling release code that
-#                             uses TBB.
-# * TBB_DEFINITIONS_DEBUG   - Definitions to use when compiling debug code that
-#                             uses TBB.
-#
-# This module will also create the "tbb" target that may be used when building
-# executables and libraries.
 
-include(FindPackageHandleStandardArgs)
+#=============================================================================
+#  FindTBB helper functions and macros
+#=============================================================================
 
-if (NOT TBB_FOUND)
+#====================================================
+# Fix the library path in case it is a linker script
+#====================================================
+function(tbb_extract_real_library library real_library)
+    if (NOT UNIX OR NOT EXISTS ${library})
+        set(${real_library} "${library}" PARENT_SCOPE)
+        return()
+    endif ()
 
-    ##################################
-    # Check the build type
-    ##################################
+    #Read in the first 4 bytes and see if they are the ELF magic number
+    set(_elf_magic "7f454c46")
+    file(READ ${library} _hex_data OFFSET 0 LIMIT 4 HEX)
+    if (_hex_data STREQUAL _elf_magic)
+        #we have opened a elf binary so this is what
+        #we should link to
+        set(${real_library} "${library}" PARENT_SCOPE)
+        return()
+    endif ()
 
-    if (NOT DEFINED TBB_USE_DEBUG_BUILD)
-        if (CMAKE_BUILD_TYPE MATCHES "(Debug|DEBUG|debug|RelWithDebInfo|RELWITHDEBINFO|relwithdebinfo)")
-            set(TBB_BUILD_TYPE DEBUG)
-        else ()
-            set(TBB_BUILD_TYPE RELEASE)
-        endif ()
-    elseif (TBB_USE_DEBUG_BUILD)
-        set(TBB_BUILD_TYPE DEBUG)
+    file(READ ${library} _data OFFSET 0 LIMIT 1024)
+    if ("${_data}" MATCHES "INPUT \\(([^(]+)\\)")
+        #extract out the .so name from REGEX MATCH command
+        set(_proper_so_name "${CMAKE_MATCH_1}")
+
+        #construct path to the real .so which is presumed to be in the same directory
+        #as the input file
+        get_filename_component(_so_dir "${library}" DIRECTORY)
+        set(${real_library} "${_so_dir}/${_proper_so_name}" PARENT_SCOPE)
     else ()
-        set(TBB_BUILD_TYPE RELEASE)
+        #unable to determine what this library is so just hope everything works
+        #and pass it unmodified.
+        set(${real_library} "${library}" PARENT_SCOPE)
     endif ()
+endfunction()
 
-    ##################################
-    # Set the TBB search directories
-    ##################################
-
-    # Define search paths based on user input and environment variables
-    set(TBB_SEARCH_DIR ${TBB_ROOT_DIR} $ENV{TBB_INSTALL_DIR} $ENV{TBBROOT})
-
-    # Define the search directories based on the current platform
-    if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-        set(TBB_DEFAULT_SEARCH_DIR "C:/Program Files/Intel/TBB"
-                "C:/Program Files (x86)/Intel/TBB")
-
-        # Set the target architecture
-        if (CMAKE_SIZEOF_VOID_P EQUAL 8)
-            set(TBB_ARCHITECTURE "intel64")
-        else ()
-            set(TBB_ARCHITECTURE "ia32")
-        endif ()
-
-        # Set the TBB search library path search suffix based on the version of VC
-        if (WINDOWS_STORE)
-            set(TBB_LIB_PATH_SUFFIX "lib/${TBB_ARCHITECTURE}/vc11_ui")
-        elseif (MSVC14)
-            set(TBB_LIB_PATH_SUFFIX "lib/${TBB_ARCHITECTURE}/vc14")
-        elseif (MSVC12)
-            set(TBB_LIB_PATH_SUFFIX "lib/${TBB_ARCHITECTURE}/vc12")
-        elseif (MSVC11)
-            set(TBB_LIB_PATH_SUFFIX "lib/${TBB_ARCHITECTURE}/vc11")
-        elseif (MSVC10)
-            set(TBB_LIB_PATH_SUFFIX "lib/${TBB_ARCHITECTURE}/vc10")
-        endif ()
-
-        # Add the library path search suffix for the VC independent version of TBB
-        list(APPEND TBB_LIB_PATH_SUFFIX "lib/${TBB_ARCHITECTURE}/vc_mt")
-
-    elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-        # OS X
-        set(TBB_DEFAULT_SEARCH_DIR "/opt/intel/tbb")
-
-        # TODO: Check to see which C++ library is being used by the compiler.
-        if (NOT ${CMAKE_SYSTEM_VERSION} VERSION_LESS 13.0)
-            # The default C++ library on OS X 10.9 and later is libc++
-            set(TBB_LIB_PATH_SUFFIX "lib/libc++" "lib")
-        else ()
-            set(TBB_LIB_PATH_SUFFIX "lib")
-        endif ()
-    elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-        # Linux
-        set(TBB_DEFAULT_SEARCH_DIR "/opt/intel/tbb")
-
-        # TODO: Check compiler version to see the suffix should be <arch>/gcc4.1 or
-        #       <arch>/gcc4.1. For now, assume that the compiler is more recent than
-        #       gcc 4.4.x or later.
-        if (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-            set(TBB_LIB_PATH_SUFFIX "lib/intel64/gcc4.4")
-        elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^i.86$")
-            set(TBB_LIB_PATH_SUFFIX "lib/ia32/gcc4.4")
-        endif ()
-    endif ()
-
-    ##################################
-    # Find the TBB include dir
-    ##################################
-
-    find_path(TBB_INCLUDE_DIRS tbb/tbb.h
-            HINTS ${TBB_INCLUDE_DIR} ${TBB_SEARCH_DIR}
-            PATHS ${TBB_DEFAULT_SEARCH_DIR}
-            PATH_SUFFIXES include)
-
-    ##################################
-    # Set version strings
-    ##################################
-
-    if (TBB_INCLUDE_DIRS)
-        file(READ "${TBB_INCLUDE_DIRS}/oneapi/tbb/version.h" _tbb_version_file)
-        string(REGEX REPLACE ".*#define TBB_VERSION_MAJOR ([0-9]+).*" "\\1"
-                TBB_VERSION_MAJOR "${_tbb_version_file}")
-        string(REGEX REPLACE ".*#define TBB_VERSION_MINOR ([0-9]+).*" "\\1"
-                TBB_VERSION_MINOR "${_tbb_version_file}")
-        string(REGEX REPLACE ".*#define TBB_INTERFACE_VERSION ([0-9]+).*" "\\1"
-                TBB_INTERFACE_VERSION "${_tbb_version_file}")
-        set(TBB_VERSION "${TBB_VERSION_MAJOR}.${TBB_VERSION_MINOR}")
-    endif ()
-
-    ##################################
-    # Find TBB components
-    ##################################
-
-    if (TBB_VERSION VERSION_LESS 4.3)
-        set(TBB_SEARCH_COMPOMPONENTS tbb_preview tbbmalloc tbb)
+#===============================================
+# Do the final processing for the package find.
+#===============================================
+macro(findpkg_finish PREFIX TARGET_NAME)
+    if (${PREFIX}_INCLUDE_DIR AND ${PREFIX}_LIBRARY)
+        set(${PREFIX}_FOUND TRUE)
+        set(${PREFIX}_INCLUDE_DIRS ${${PREFIX}_INCLUDE_DIR})
+        set(${PREFIX}_LIBRARIES ${${PREFIX}_LIBRARY})
     else ()
-        set(TBB_SEARCH_COMPOMPONENTS tbb_preview tbbmalloc_proxy tbbmalloc tbb)
+        if (${PREFIX}_FIND_REQUIRED AND NOT ${PREFIX}_FIND_QUIETLY)
+            message(FATAL_ERROR "Required library ${PREFIX} not found.")
+        endif ()
     endif ()
 
-    # Find each component
-    foreach (_comp ${TBB_SEARCH_COMPOMPONENTS})
-        if (";${TBB_FIND_COMPONENTS};tbb;" MATCHES ";${_comp};")
+    if (NOT TARGET "TBB::${TARGET_NAME}")
+        if (${PREFIX}_LIBRARY_RELEASE)
+            tbb_extract_real_library(${${PREFIX}_LIBRARY_RELEASE} real_release)
+        endif ()
+        if (${PREFIX}_LIBRARY_DEBUG)
+            tbb_extract_real_library(${${PREFIX}_LIBRARY_DEBUG} real_debug)
+        endif ()
+        add_library(TBB::${TARGET_NAME} UNKNOWN IMPORTED)
+        set_target_properties(TBB::${TARGET_NAME} PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${${PREFIX}_INCLUDE_DIR}")
+        if (${PREFIX}_LIBRARY_DEBUG AND ${PREFIX}_LIBRARY_RELEASE)
+            set_target_properties(TBB::${TARGET_NAME} PROPERTIES
+                    IMPORTED_LOCATION "${real_release}"
+                    IMPORTED_LOCATION_DEBUG "${real_debug}"
+                    IMPORTED_LOCATION_RELEASE "${real_release}")
+        elseif (${PREFIX}_LIBRARY_RELEASE)
+            set_target_properties(TBB::${TARGET_NAME} PROPERTIES
+                    IMPORTED_LOCATION "${real_release}")
+        elseif (${PREFIX}_LIBRARY_DEBUG)
+            set_target_properties(TBB::${TARGET_NAME} PROPERTIES
+                    IMPORTED_LOCATION "${real_debug}")
+        endif ()
+    endif ()
 
-            # Search for the libraries
-            find_library(TBB_${_comp}_LIBRARY_RELEASE ${_comp}
-                    HINTS ${TBB_LIBRARY} ${TBB_SEARCH_DIR}
-                    PATHS ${TBB_DEFAULT_SEARCH_DIR} ENV LIBRARY_PATH
-                    PATH_SUFFIXES ${TBB_LIB_PATH_SUFFIX})
+    #mark the following variables as internal variables
+    mark_as_advanced(${PREFIX}_INCLUDE_DIR
+            ${PREFIX}_LIBRARY
+            ${PREFIX}_LIBRARY_DEBUG
+            ${PREFIX}_LIBRARY_RELEASE)
+endmacro()
 
-            find_library(TBB_${_comp}_LIBRARY_DEBUG ${_comp}_debug
-                    HINTS ${TBB_LIBRARY} ${TBB_SEARCH_DIR}
-                    PATHS ${TBB_DEFAULT_SEARCH_DIR} ENV LIBRARY_PATH
-                    PATH_SUFFIXES ${TBB_LIB_PATH_SUFFIX})
+#===============================================
+# Generate debug names from given release names
+#===============================================
+macro(get_debug_names PREFIX)
+    foreach (i ${${PREFIX}})
+        set(${PREFIX}_DEBUG ${${PREFIX}_DEBUG} ${i}d ${i}D ${i}_d ${i}_D ${i}_debug ${i})
+    endforeach ()
+endmacro()
 
-            if (TBB_${_comp}_LIBRARY_DEBUG)
-                list(APPEND TBB_LIBRARIES_DEBUG "${TBB_${_comp}_LIBRARY_DEBUG}")
-            endif ()
-            if (TBB_${_comp}_LIBRARY_RELEASE)
-                list(APPEND TBB_LIBRARIES_RELEASE "${TBB_${_comp}_LIBRARY_RELEASE}")
-            endif ()
-            if (TBB_${_comp}_LIBRARY_${TBB_BUILD_TYPE} AND NOT TBB_${_comp}_LIBRARY)
-                set(TBB_${_comp}_LIBRARY "${TBB_${_comp}_LIBRARY_${TBB_BUILD_TYPE}}")
-            endif ()
+#===============================================
+# See if we have env vars to help us find tbb
+#===============================================
+macro(getenv_path VAR)
+    set(ENV_${VAR} $ENV{${VAR}})
+    # replace won't work if var is blank
+    if (ENV_${VAR})
+        string(REGEX REPLACE "\\\\" "/" ENV_${VAR} ${ENV_${VAR}})
+    endif ()
+endmacro()
 
-            if (TBB_${_comp}_LIBRARY AND EXISTS "${TBB_${_comp}_LIBRARY}")
-                set(TBB_${_comp}_FOUND TRUE)
-            else ()
-                set(TBB_${_comp}_FOUND FALSE)
-            endif ()
+#===============================================
+# Couple a set of release AND debug libraries
+#===============================================
+macro(make_library_set PREFIX)
+    if (${PREFIX}_RELEASE AND ${PREFIX}_DEBUG)
+        set(${PREFIX} optimized ${${PREFIX}_RELEASE} debug ${${PREFIX}_DEBUG})
+    elseif (${PREFIX}_RELEASE)
+        set(${PREFIX} ${${PREFIX}_RELEASE})
+    elseif (${PREFIX}_DEBUG)
+        set(${PREFIX} ${${PREFIX}_DEBUG})
+    endif ()
+endmacro()
 
-            # Mark internal variables as advanced
-            mark_as_advanced(TBB_${_comp}_LIBRARY_RELEASE)
-            mark_as_advanced(TBB_${_comp}_LIBRARY_DEBUG)
-            mark_as_advanced(TBB_${_comp}_LIBRARY)
 
+#=============================================================================
+#  Now to actually find TBB
+#
+
+# Get path, convert backslashes as ${ENV_${var}}
+getenv_path(TBB_ROOT)
+
+# initialize search paths
+set(TBB_PREFIX_PATH ${TBB_ROOT} ${ENV_TBB_ROOT})
+set(TBB_INC_SEARCH_PATH "")
+set(TBB_LIB_SEARCH_PATH "")
+
+
+# If user built from sources
+set(TBB_BUILD_PREFIX $ENV{TBB_BUILD_PREFIX})
+if (TBB_BUILD_PREFIX AND ENV_TBB_ROOT)
+    getenv_path(TBB_BUILD_DIR)
+    if (NOT ENV_TBB_BUILD_DIR)
+        set(ENV_TBB_BUILD_DIR ${ENV_TBB_ROOT}/build)
+    endif ()
+
+    # include directory under ${ENV_TBB_ROOT}/include
+    list(APPEND TBB_LIB_SEARCH_PATH
+            ${ENV_TBB_BUILD_DIR}/${TBB_BUILD_PREFIX}_release
+            ${ENV_TBB_BUILD_DIR}/${TBB_BUILD_PREFIX}_debug)
+endif ()
+
+
+# For Windows, let's assume that the user might be using the precompiled
+# TBB packages from the main website. These use a rather awkward directory
+# structure (at least for automatically finding the right files) depending
+# on platform and compiler, but we'll do our best to accommodate it.
+# Not adding the same effort for the precompiled linux builds, though. Those
+# have different versions for CC compiler versions and linux kernels which
+# will never adequately match the user's setup, so there is no feasible way
+# to detect the "best" version to use. The user will have to manually
+# select the right files. (Chances are the distributions are shipping their
+# custom version of tbb, anyway, so the problem is probably nonexistent.)
+if (WIN32 AND MSVC)
+    set(COMPILER_PREFIX "vc7.1")
+    if (MSVC_VERSION EQUAL 1400)
+        set(COMPILER_PREFIX "vc8")
+    elseif (MSVC_VERSION EQUAL 1500)
+        set(COMPILER_PREFIX "vc9")
+    elseif (MSVC_VERSION EQUAL 1600)
+        set(COMPILER_PREFIX "vc10")
+    elseif (MSVC_VERSION EQUAL 1700)
+        set(COMPILER_PREFIX "vc11")
+    elseif (MSVC_VERSION EQUAL 1800)
+        set(COMPILER_PREFIX "vc12")
+    elseif (MSVC_VERSION GREATER_EQUAL 1900)
+        set(COMPILER_PREFIX "vc14")
+    endif ()
+
+    # for each prefix path, add ia32/64\${COMPILER_PREFIX}\lib to the lib search path
+    foreach (dir IN LISTS TBB_PREFIX_PATH)
+        if (CMAKE_CL_64)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/ia64/${COMPILER_PREFIX}/lib)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/ia64/${COMPILER_PREFIX})
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/intel64/${COMPILER_PREFIX}/lib)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/intel64/${COMPILER_PREFIX})
+        else ()
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/ia32/${COMPILER_PREFIX}/lib)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/ia32/${COMPILER_PREFIX})
         endif ()
     endforeach ()
+endif ()
 
-    ##################################
-    # Set compile flags and libraries
-    ##################################
+# For OS X binary distribution, choose libc++ based libraries for Mavericks (10.9)
+# and above and AppleClang
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND
+        NOT CMAKE_SYSTEM_VERSION VERSION_LESS 13.0)
+    set(USE_LIBCXX OFF)
+    cmake_policy(GET CMP0025 POLICY_VAR)
 
-    set(TBB_DEFINITIONS_RELEASE "")
-    set(TBB_DEFINITIONS_DEBUG "-DTBB_USE_DEBUG=1")
-
-    if (TBB_LIBRARIES_${TBB_BUILD_TYPE})
-        set(TBB_DEFINITIONS "${TBB_DEFINITIONS_${TBB_BUILD_TYPE}}")
-        set(TBB_LIBRARIES "${TBB_LIBRARIES_${TBB_BUILD_TYPE}}")
-    elseif (TBB_LIBRARIES_RELEASE)
-        set(TBB_DEFINITIONS "${TBB_DEFINITIONS_RELEASE}")
-        set(TBB_LIBRARIES "${TBB_LIBRARIES_RELEASE}")
-    elseif (TBB_LIBRARIES_DEBUG)
-        set(TBB_DEFINITIONS "${TBB_DEFINITIONS_DEBUG}")
-        set(TBB_LIBRARIES "${TBB_LIBRARIES_DEBUG}")
-    endif ()
-
-    find_package_handle_standard_args(TBB
-            REQUIRED_VARS TBB_INCLUDE_DIRS TBB_LIBRARIES
-            HANDLE_COMPONENTS
-            VERSION_VAR TBB_VERSION)
-
-    ##################################
-    # Create targets
-    ##################################
-
-    if (NOT CMAKE_VERSION VERSION_LESS 3.0 AND TBB_FOUND)
-        add_library(tbb SHARED IMPORTED)
-        set_target_properties(tbb PROPERTIES
-                INTERFACE_INCLUDE_DIRECTORIES ${TBB_INCLUDE_DIRS}
-                IMPORTED_LOCATION ${TBB_LIBRARIES})
-        if (TBB_LIBRARIES_RELEASE AND TBB_LIBRARIES_DEBUG)
-            set_target_properties(tbb PROPERTIES
-                    INTERFACE_COMPILE_DEFINITIONS "$<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:TBB_USE_DEBUG=1>"
-                    IMPORTED_LOCATION_DEBUG ${TBB_LIBRARIES_DEBUG}
-                    IMPORTED_LOCATION_RELWITHDEBINFO ${TBB_LIBRARIES_DEBUG}
-                    IMPORTED_LOCATION_RELEASE ${TBB_LIBRARIES_RELEASE}
-                    IMPORTED_LOCATION_MINSIZEREL ${TBB_LIBRARIES_RELEASE}
-                    )
-        elseif (TBB_LIBRARIES_RELEASE)
-            set_target_properties(tbb PROPERTIES IMPORTED_LOCATION ${TBB_LIBRARIES_RELEASE})
-        else ()
-            set_target_properties(tbb PROPERTIES
-                    INTERFACE_COMPILE_DEFINITIONS "${TBB_DEFINITIONS_DEBUG}"
-                    IMPORTED_LOCATION ${TBB_LIBRARIES_DEBUG}
-                    )
+    if (POLICY_VAR STREQUAL "NEW")
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+            set(USE_LIBCXX ON)
+        endif ()
+    else ()
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+            set(USE_LIBCXX ON)
         endif ()
     endif ()
 
-    mark_as_advanced(TBB_INCLUDE_DIRS TBB_LIBRARIES)
+    if (USE_LIBCXX)
+        foreach (dir IN LISTS TBB_PREFIX_PATH)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/libc++ ${dir}/libc++/lib)
+        endforeach ()
+    endif ()
+endif ()
 
-    unset(TBB_ARCHITECTURE)
-    unset(TBB_BUILD_TYPE)
-    unset(TBB_LIB_PATH_SUFFIX)
-    unset(TBB_DEFAULT_SEARCH_DIR)
+# check compiler ABI
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(COMPILER_PREFIX)
+    if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
+        list(APPEND COMPILER_PREFIX "gcc4.8")
+    endif ()
+    if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.7)
+        list(APPEND COMPILER_PREFIX "gcc4.7")
+    endif ()
+    if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4)
+        list(APPEND COMPILER_PREFIX "gcc4.4")
+    endif ()
+    list(APPEND COMPILER_PREFIX "gcc4.1")
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(COMPILER_PREFIX)
+    if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.0) # Complete guess
+        list(APPEND COMPILER_PREFIX "gcc4.8")
+    endif ()
+    if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.6)
+        list(APPEND COMPILER_PREFIX "gcc4.7")
+    endif ()
+    list(APPEND COMPILER_PREFIX "gcc4.4")
+else () # Assume compatibility with 4.4 for other compilers
+    list(APPEND COMPILER_PREFIX "gcc4.4")
+endif ()
+
+# if platform architecture is explicitly specified
+set(TBB_ARCH_PLATFORM $ENV{TBB_ARCH_PLATFORM})
+if (TBB_ARCH_PLATFORM)
+    foreach (dir IN LISTS TBB_PREFIX_PATH)
+        list(APPEND TBB_LIB_SEARCH_PATH ${dir}/${TBB_ARCH_PLATFORM}/lib)
+        list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/${TBB_ARCH_PLATFORM})
+    endforeach ()
+endif ()
+
+foreach (dir IN LISTS TBB_PREFIX_PATH)
+    foreach (prefix IN LISTS COMPILER_PREFIX)
+        if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/intel64)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/intel64/${prefix})
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/intel64/lib)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/intel64/${prefix}/lib)
+        else ()
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/ia32)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/ia32/${prefix})
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/ia32/lib)
+            list(APPEND TBB_LIB_SEARCH_PATH ${dir}/ia32/${prefix}/lib)
+        endif ()
+    endforeach ()
+endforeach ()
+
+# add general search paths
+foreach (dir IN LISTS TBB_PREFIX_PATH)
+    list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib ${dir}/Lib ${dir}/lib/tbb
+            ${dir}/Libs)
+    list(APPEND TBB_INC_SEARCH_PATH ${dir}/include ${dir}/Include
+            ${dir}/include/tbb)
+endforeach ()
+
+set(TBB_LIBRARY_NAMES tbb)
+get_debug_names(TBB_LIBRARY_NAMES)
+
+
+find_path(TBB_INCLUDE_DIR
+        NAMES tbb/tbb.h
+        PATHS ${TBB_INC_SEARCH_PATH})
+
+find_library(TBB_LIBRARY_RELEASE
+        NAMES ${TBB_LIBRARY_NAMES}
+        PATHS ${TBB_LIB_SEARCH_PATH})
+find_library(TBB_LIBRARY_DEBUG
+        NAMES ${TBB_LIBRARY_NAMES_DEBUG}
+        PATHS ${TBB_LIB_SEARCH_PATH})
+make_library_set(TBB_LIBRARY)
+
+findpkg_finish(TBB tbb)
+
+#if we haven't found TBB no point on going any further
+if (NOT TBB_FOUND)
+    return()
+endif ()
+
+#=============================================================================
+# Look for TBB's malloc package
+set(TBB_MALLOC_LIBRARY_NAMES tbbmalloc)
+get_debug_names(TBB_MALLOC_LIBRARY_NAMES)
+
+find_path(TBB_MALLOC_INCLUDE_DIR
+        NAMES tbb/tbb.h
+        PATHS ${TBB_INC_SEARCH_PATH})
+
+find_library(TBB_MALLOC_LIBRARY_RELEASE
+        NAMES ${TBB_MALLOC_LIBRARY_NAMES}
+        PATHS ${TBB_LIB_SEARCH_PATH})
+find_library(TBB_MALLOC_LIBRARY_DEBUG
+        NAMES ${TBB_MALLOC_LIBRARY_NAMES_DEBUG}
+        PATHS ${TBB_LIB_SEARCH_PATH})
+make_library_set(TBB_MALLOC_LIBRARY)
+
+findpkg_finish(TBB_MALLOC tbbmalloc)
+
+#=============================================================================
+# Look for TBB's malloc proxy package
+set(TBB_MALLOC_PROXY_LIBRARY_NAMES tbbmalloc_proxy)
+get_debug_names(TBB_MALLOC_PROXY_LIBRARY_NAMES)
+
+find_path(TBB_MALLOC_PROXY_INCLUDE_DIR
+        NAMES tbb/tbbmalloc_proxy.h
+        PATHS ${TBB_INC_SEARCH_PATH})
+
+find_library(TBB_MALLOC_PROXY_LIBRARY_RELEASE
+        NAMES ${TBB_MALLOC_PROXY_LIBRARY_NAMES}
+        PATHS ${TBB_LIB_SEARCH_PATH})
+find_library(TBB_MALLOC_PROXY_LIBRARY_DEBUG
+        NAMES ${TBB_MALLOC_PROXY_LIBRARY_NAMES_DEBUG}
+        PATHS ${TBB_LIB_SEARCH_PATH})
+make_library_set(TBB_MALLOC_PROXY_LIBRARY)
+
+findpkg_finish(TBB_MALLOC_PROXY tbbmalloc_proxy)
+
+
+#=============================================================================
+#parse all the version numbers from tbb
+if (NOT TBB_VERSION)
+    if (EXISTS "${TBB_INCLUDE_DIR}/oneapi/tbb/version.h")
+        file(STRINGS
+                "${TBB_INCLUDE_DIR}/oneapi/tbb/version.h"
+                TBB_VERSION_CONTENTS
+                REGEX "VERSION")
+    else ()
+        #only read the start of the file
+        file(STRINGS
+                "${TBB_INCLUDE_DIR}/tbb/tbb_stddef.h"
+                TBB_VERSION_CONTENTS
+                REGEX "VERSION")
+    endif ()
+
+    string(REGEX REPLACE
+            ".*#define TBB_VERSION_MAJOR ([0-9]+).*" "\\1"
+            TBB_VERSION_MAJOR "${TBB_VERSION_CONTENTS}")
+
+    string(REGEX REPLACE
+            ".*#define TBB_VERSION_MINOR ([0-9]+).*" "\\1"
+            TBB_VERSION_MINOR "${TBB_VERSION_CONTENTS}")
+
+    string(REGEX REPLACE
+            ".*#define TBB_INTERFACE_VERSION ([0-9]+).*" "\\1"
+            TBB_INTERFACE_VERSION "${TBB_VERSION_CONTENTS}")
+
+    string(REGEX REPLACE
+            ".*#define TBB_COMPATIBLE_INTERFACE_VERSION ([0-9]+).*" "\\1"
+            TBB_COMPATIBLE_INTERFACE_VERSION "${TBB_VERSION_CONTENTS}")
 
 endif ()

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -19,6 +19,10 @@ them automatically. Should the repository have been cloned before, the commands:
 
 will fetch the latest version of all external modules used. Additionally, only ``CMake`` and a C++17 compiler are required.
 
+At the time of writing, for parallel STL algorithms to work when using GCC, the TBB library (``libtbb-dev`` on ubuntu) is
+needed. It is an optional dependency that can be installed for a performance boost in certain scenarios. For your
+preferred compiler, see the current implementation state of `P0024R2 <https://en.cppreference.com/w/cpp/compiler_support/17>`_.
+
 
 Using *fiction* as a stand-alone CLI tool
 -----------------------------------------

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -76,3 +76,24 @@ if (FICTION_Z3)
     endif ()
 
 endif ()
+
+# If using GCC, find TBB if installed
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/") # include FindTBB.cmake
+    find_package(TBB)
+    if (TBB_FOUND)
+        # Status update
+        message(STATUS "Found TBB version: ${TBB_VERSION}")
+        message(STATUS "Found TBB library: ${TBB_LIBRARIES}")
+        message(STATUS "Parallel STL algorithms are enabled")
+
+        # Compile definitions
+        target_compile_definitions(libfiction INTERFACE ${TBB_DEFINITIONS})
+        # Include TBB
+        target_include_directories(libfiction INTERFACE ${TBB_INCLUDE_DIRS})
+        # Link TBB
+        target_link_libraries(libfiction INTERFACE ${TBB_LIBRARIES})
+    else ()
+        message(STATUS "Parallel STL algorithms are disabled. If you want to use them, please install TBB and set the TBB_ROOT_DIR, TBB_INCLUDE_DIR, and TBB_LIBRARY variables accordingly.")
+    endif ()
+endif ()

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -83,16 +83,13 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     find_package(TBB)
     if (TBB_FOUND)
         # Status update
-        message(STATUS "Found TBB version: ${TBB_VERSION}")
-        message(STATUS "Found TBB library: ${TBB_LIBRARIES}")
+        message(STATUS "Found TBB version: ${TBB_VERSION_MAJOR}.${TBB_VERSION_MINOR}")
         message(STATUS "Parallel STL algorithms are enabled")
 
-        # Compile definitions
-        target_compile_definitions(libfiction INTERFACE ${TBB_DEFINITIONS})
         # Include TBB
         target_include_directories(libfiction INTERFACE ${TBB_INCLUDE_DIRS})
         # Link TBB
-        target_link_libraries(libfiction INTERFACE ${TBB_LIBRARIES})
+        target_link_libraries(libfiction INTERFACE TBB::tbb)
     else ()
         message(STATUS "Parallel STL algorithms are disabled. If you want to use them, please install TBB and set the TBB_ROOT_DIR, TBB_INCLUDE_DIR, and TBB_LIBRARY variables accordingly.")
     endif ()


### PR DESCRIPTION
GCC requires TBB to benefit from potential performance gains when using parallel STL algorithms. This PR introduces automatic linking against TBB if found on the system.

Should the implementation status of [P0024R2](https://en.cppreference.com/w/cpp/compiler_support/17) be updated in the future, the changes from this PR can be reverted.