### PR TITLE
:construction_worker: Z3 setup action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ defaults:
 
 env:
   BUILD_TYPE: Debug
-  Z3_GIT_TAG: z3-4.10.0
+  Z3_VERSION: 4.10.0
 
 jobs:
   build_and_test:
@@ -40,20 +40,15 @@ jobs:
         with:
           requirements: ${{github.workspace}}/libs/mugen/requirements.txt
 
-      - name: Cache Z3 Solver
-        id: cache-z3-solver
-        uses: actions/cache@v3
+      - name: Setup Z3 Solver
+        id: z3
+        uses: cda-tum/setup-z3@v1
         with:
-          path: ${{github.workspace}}/z3lib
-          key: ${{matrix.os}}-${{matrix.compiler}}-z3lib-${{env.Z3_GIT_TAG}}
-
-      - name: Build Z3 Solver
-        if: steps.cache-z3-solver.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-        run: |
-          git clone --branch $Z3_GIT_TAG --depth 1 https://github.com/Z3Prover/z3.git
-          cmake -S z3 -B z3/build -DCMAKE_INSTALL_PREFIX=z3lib -DZ3_BUILD_LIBZ3_SHARED=OFF -DZ3_BUILD_TEST_EXECUTABLES=OFF -DZ3_ENABLE_EXAMPLE_TARGETS=OFF
-          cmake --build z3/build --config Release -j2 --target install
+          version: ${{env.Z3_VERSION}}
+          platform: linux
+          architecture: x64
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build
@@ -61,7 +56,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
 
-        run: cmake ${{github.workspace}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_Z3_SEARCH_PATHS=${{github.workspace}}/z3lib -DFICTION_ENABLE_MUGEN=ON -DFICTION_PROGRESS_BARS=OFF -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF -DENABLE_COVERAGE=ON
+        run: cmake ${{github.workspace}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_Z3_SEARCH_PATHS=${{steps.z3.outputs.z3-root}} -DFICTION_ENABLE_MUGEN=ON -DFICTION_PROGRESS_BARS=OFF -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF -DENABLE_COVERAGE=ON
 
       - name: Build
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
 
-        run: cmake ${{github.workspace}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_Z3_SEARCH_PATHS=${{steps.z3.outputs.z3-root}} -DFICTION_ENABLE_MUGEN=ON -DFICTION_PROGRESS_BARS=OFF -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF -DENABLE_COVERAGE=ON
+        run: cmake ${{github.workspace}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_ENABLE_MUGEN=ON -DFICTION_PROGRESS_BARS=OFF -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF -DENABLE_COVERAGE=ON
 
       - name: Build
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,7 @@
 name: Coverage CI
 
-on: push
+on:
+  pull_request:
 
 defaults:
   run:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
 
-        run: cmake ${{github.workspace}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_Z3_SEARCH_PATHS=${{steps.z3.outputs.z3-root}} -DFICTION_PROGRESS_BARS=OFF -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
+        run: cmake ${{github.workspace}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_PROGRESS_BARS=OFF -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ defaults:
     shell: bash
 
 env:
-  Z3_GIT_TAG: z3-4.10.0
+  Z3_VERSION: 4.10.0
 
 jobs:
   build_and_test:
@@ -46,20 +46,15 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Cache Z3 Solver
-        id: cache-z3-solver
-        uses: actions/cache@v3
+      - name: Setup Z3 Solver
+        id: z3
+        uses: cda-tum/setup-z3@v1
         with:
-          path: ${{github.workspace}}/z3lib
-          key: ${{matrix.os}}-${{matrix.compiler}}-z3lib-${{env.Z3_GIT_TAG}}  # use compiler in key because linking z3 to fiction when compiled differently does not work under macOS
-
-      - name: Build Z3 Solver
-        if: steps.cache-z3-solver.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-        run: |
-          git clone --branch $Z3_GIT_TAG --depth 1 https://github.com/Z3Prover/z3.git
-          CC=${{matrix.ccompiler}} CXX=${{matrix.compiler}} cmake -S z3 -B z3/build -DCMAKE_INSTALL_PREFIX=z3lib -DZ3_BUILD_LIBZ3_SHARED=OFF -DZ3_BUILD_TEST_EXECUTABLES=OFF -DZ3_ENABLE_EXAMPLE_TARGETS=OFF
-          cmake --build z3/build --config Release -j3 --target install
+          version: ${{env.Z3_VERSION}}
+          platform: macOS
+          architecture: x64
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build
@@ -67,7 +62,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
 
-        run: cmake ${{github.workspace}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_Z3_SEARCH_PATHS=${{github.workspace}}/z3lib -DFICTION_PROGRESS_BARS=OFF -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
+        run: cmake ${{github.workspace}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_Z3_SEARCH_PATHS=${{steps.z3.outputs.z3-root}} -DFICTION_PROGRESS_BARS=OFF -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
 
-        run: cmake ${{github.workspace}} ${{matrix.cppstandard}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_Z3_SEARCH_PATHS=${{steps.z3.outputs.z3-root}} -DFICTION_ENABLE_MUGEN=ON -DFICTION_PROGRESS_BARS=OFF -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
+        run: cmake ${{github.workspace}} ${{matrix.cppstandard}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_ENABLE_MUGEN=ON -DFICTION_PROGRESS_BARS=OFF -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build fiction
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,7 +7,7 @@ defaults:
     shell: bash
 
 env:
-  Z3_GIT_TAG: z3-4.10.0
+  Z3_VERSION: 4.10.0
 
 jobs:
   build_and_test:
@@ -48,20 +48,15 @@ jobs:
         with:
           requirements: ${{github.workspace}}/libs/mugen/requirements.txt
 
-      - name: Cache Z3 Solver
-        id: cache-z3-solver
-        uses: actions/cache@v3
+      - name: Setup Z3 Solver
+        id: z3
+        uses: cda-tum/setup-z3@v1
         with:
-          path: ${{github.workspace}}/z3lib
-          key: ${{matrix.os}}-${{matrix.compiler}}-z3lib-${{env.Z3_GIT_TAG}}
-
-      - name: Build Z3 Solver
-        if: steps.cache-z3-solver.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-        run: |
-          git clone --branch $Z3_GIT_TAG --depth 1 https://github.com/Z3Prover/z3.git
-          cmake -S z3 -B z3/build -DCMAKE_INSTALL_PREFIX=z3lib -DZ3_BUILD_LIBZ3_SHARED=OFF -DZ3_BUILD_TEST_EXECUTABLES=OFF -DZ3_ENABLE_EXAMPLE_TARGETS=OFF
-          cmake --build z3/build --config Release -j2 --target install
+          version: ${{env.Z3_VERSION}}
+          platform: linux
+          architecture: x64
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build
@@ -69,7 +64,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
 
-        run: cmake ${{github.workspace}} ${{matrix.cppstandard}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_Z3_SEARCH_PATHS=${{github.workspace}}/z3lib -DFICTION_ENABLE_MUGEN=ON -DFICTION_PROGRESS_BARS=OFF -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
+        run: cmake ${{github.workspace}} ${{matrix.cppstandard}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_Z3_SEARCH_PATHS=${{steps.z3.outputs.z3-root}} -DFICTION_ENABLE_MUGEN=ON -DFICTION_PROGRESS_BARS=OFF -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build fiction
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ defaults:
     shell: pwsh  # use pwsh as directory handling does not seem to work with bash
 
 env:
-  Z3_GIT_TAG: z3-4.10.0
+  Z3_VERSION: 4.10.0
 
 jobs:
   build_and_test:
@@ -36,21 +36,15 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Cache Z3 Solver
-        id: cache-z3-solver
-        uses: actions/cache@v3
+      - name: Setup Z3 Solver
+        id: z3
+        uses: cda-tum/setup-z3@v1
         with:
-          path: ${{github.workspace}}\z3lib
-          key: ${{matrix.os}}-${{matrix.toolset}}-z3lib-${{matrix.build_type}}-${{env.Z3_GIT_TAG}}  # use build_type in the key because linking z3 to fiction with different build types does not work under windows
-
-      - name: Build Z3 Solver
-        if: steps.cache-z3-solver.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-        shell: bash
-        run: |
-          git clone --branch $Z3_GIT_TAG --depth 1 https://github.com/Z3Prover/z3.git
-          cmake -S z3 -B z3\build -G "${{matrix.env}}" -A x64 -DCMAKE_INSTALL_PREFIX=z3lib -DZ3_BUILD_LIBZ3_SHARED=OFF -DZ3_BUILD_TEST_EXECUTABLES=OFF -DZ3_ENABLE_EXAMPLE_TARGETS=OFF
-          cmake --build z3\build --config ${{matrix.build_type}} -j2 --target install
+          version: ${{env.Z3_VERSION}}
+          platform: windows
+          architecture: x64
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}\build
@@ -58,7 +52,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}\build
 
-        run: cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_Z3_SEARCH_PATHS=${{github.workspace}}\z3lib -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
+        run: cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_Z3_SEARCH_PATHS=${{steps.z3.outputs.z3-root}} -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}\build
 
-        run: cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_Z3_SEARCH_PATHS=${{steps.z3.outputs.z3-root}} -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
+        run: cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build
         working-directory: ${{github.workspace}}\build

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,9 @@ ARG NUMBER_OF_JOBS=1
 # Configure apt and install packages
 RUN apk add --no-cache \
     # Install cmake with its dependencies
-    build-base gcc abuild binutils binutils-doc gcc-doc \
-    cmake cmake-doc extra-cmake-modules extra-cmake-modules-doc \
-    #
+    build-base gcc abuild binutils cmake \
     # Install packages needed to build fiction
-    git g++ cmake python3 python3-dev readline-dev zlib-dev xdg-utils
+    git g++ python3 python3-dev readline-dev xdg-utils
 
 # Setup Z3
 RUN git clone --depth 1 --branch z3-4.10.0 https://github.com/Z3Prover/z3.git

--- a/cmake/FindZ3.cmake
+++ b/cmake/FindZ3.cmake
@@ -1,0 +1,173 @@
+# File taken from: https://github.com/cda-tum/qmap/blob/main/cmake/FindZ3.cmake
+
+# Code adapted from https://fossies.org/linux/llvm/cmake/modules/FindZ3.cmake
+include(CheckCXXSourceRuns)
+include(FindPackageHandleStandardArgs)
+
+# Function to check Z3's version
+function(check_z3_version z3_include z3_lib)
+    if (z3_include AND EXISTS "${z3_include}/z3_version.h")
+        file(STRINGS "${z3_include}/z3_version.h" z3_version_str
+                REGEX "^#define[\t ]+Z3_MAJOR_VERSION[\t ]+.*")
+        string(REGEX REPLACE "^.*Z3_MAJOR_VERSION[\t ]+([0-9]*).*$" "\\1" Z3_MAJOR "${z3_version_str}")
+
+        file(STRINGS "${z3_include}/z3_version.h" z3_version_str
+                REGEX "^#define[\t ]+Z3_MINOR_VERSION[\t ]+.*")
+        string(REGEX REPLACE "^.*Z3_MINOR_VERSION[\t ]+([0-9]*).*$" "\\1" Z3_MINOR "${z3_version_str}")
+
+        file(STRINGS "${z3_include}/z3_version.h" z3_version_str
+                REGEX "^#define[\t ]+Z3_BUILD_NUMBER[\t ]+.*")
+        string(REGEX REPLACE "^.*Z3_BUILD_NUMBER[\t ]+([0-9]*).*$" "\\1" Z3_BUILD "${z3_version_str}")
+
+        set(z3_version_string ${Z3_MAJOR}.${Z3_MINOR}.${Z3_BUILD})
+    endif ()
+
+    if (NOT z3_version_string)
+        message(STATUS "Could not determine Z3 version")
+        return()
+    endif ()
+
+    find_package_check_version(${z3_version_string} suitable_version RESULT_MESSAGE_VARIABLE reason)
+
+    if (suitable_version)
+        set(FOUND_SUITABLE_VERSION
+                TRUE
+                PARENT_SCOPE)
+        set(Z3_VERSION_STRING
+                ${z3_version_string}
+                PARENT_SCOPE)
+    else ()
+        message(STATUS "${reason}")
+    endif ()
+
+endfunction(check_z3_version)
+
+set(Z3_ROOT
+        ""
+        CACHE PATH "Root of Z3 distribution.")
+if (DEFINED ENV{Z3_ROOT})
+    set(Z3_ROOT $ENV{Z3_ROOT})
+    message(STATUS "Z3_ROOT from environment: ${Z3_ROOT}")
+endif ()
+
+# if Z3_ROOT is provided, check there first
+if (NOT ${Z3_ROOT} STREQUAL "")
+    find_path(
+            Z3_CXX_INCLUDE_DIRS
+            NAMES z3.h z3++.h
+            NO_DEFAULT_PATH
+            PATHS ${Z3_ROOT}/include
+            PATH_SUFFIXES libz3 z3)
+
+    find_library(
+            Z3_LIBRARIES
+            NAMES z3 libz3
+            NO_DEFAULT_PATH
+            PATHS ${Z3_ROOT}
+            PATH_SUFFIXES lib bin)
+
+    if (Z3_CXX_INCLUDE_DIRS AND Z3_LIBRARIES)
+        message(STATUS "Z3_ROOT provided and includes and libraries found.")
+        message(VERBOSE "Z3_CXX_INCLUDE_DIRS: ${Z3_CXX_INCLUDE_DIRS}")
+        message(VERBOSE "Z3_LIBRARIES: ${Z3_LIBRARIES}")
+        check_z3_version(${Z3_CXX_INCLUDE_DIRS} ${Z3_LIBRARIES})
+    endif ()
+endif ()
+
+# see if a config file is available
+if (NOT FOUND_SUITABLE_VERSION)
+    unset(Z3_CXX_INCLUDE_DIRS CACHE)
+    unset(Z3_LIBRARIES CACHE)
+
+    find_package(Z3 CONFIG QUIET)
+    if (Z3_FOUND)
+        message(STATUS "Found Z3 includes and libraries from config file")
+        message(VERBOSE "Z3_CXX_INCLUDE_DIRS: ${Z3_CXX_INCLUDE_DIRS}")
+        message(VERBOSE "Z3_LIBRARIES: ${Z3_LIBRARIES}")
+        check_z3_version(${Z3_CXX_INCLUDE_DIRS} ${Z3_LIBRARIES})
+    endif ()
+endif ()
+
+# if Z3 has not been found yet, look in the system paths
+if (NOT FOUND_SUITABLE_VERSION)
+    unset(Z3_CXX_INCLUDE_DIRS CACHE)
+    unset(Z3_LIBRARIES CACHE)
+
+    find_path(
+            Z3_CXX_INCLUDE_DIRS
+            NAMES z3.h z3++.h
+            PATH_SUFFIXES libz3 z3)
+    find_library(
+            Z3_LIBRARIES
+            NAMES z3 libz3
+            PATH_SUFFIXES lib bin)
+
+    if (Z3_CXX_INCLUDE_DIRS AND Z3_LIBRARIES)
+        message(STATUS "Found Z3 includes and libraries in system paths.")
+        message(VERBOSE "Z3_CXX_INCLUDE_DIRS: ${Z3_CXX_INCLUDE_DIRS}")
+        message(VERBOSE "Z3_LIBRARIES: ${Z3_LIBRARIES}")
+        check_z3_version(${Z3_CXX_INCLUDE_DIRS} ${Z3_LIBRARIES})
+    endif ()
+endif ()
+
+# if it is still not found, try to find it with Python as a last resort
+if (NOT FOUND_SUITABLE_VERSION)
+    unset(Z3_CXX_INCLUDE_DIRS CACHE)
+    unset(Z3_LIBRARIES CACHE)
+
+    set(PYTHON_FIND_VIRTUALENV FIRST)
+    find_package(Python COMPONENTS Interpreter Development.Module)
+    if (Python_FOUND)
+        execute_process(
+                COMMAND ${Python_EXECUTABLE} -c "import os, z3; print(os.path.dirname(z3.__file__))"
+                OUTPUT_VARIABLE Z3_PYTHON_ROOT)
+        string(STRIP ${Z3_PYTHON_ROOT} Z3_PYTHON_ROOT)
+        message(STATUS "Z3_PYTHON_ROOT: ${Z3_PYTHON_ROOT}")
+
+        if (Z3_PYTHON_ROOT)
+            find_path(
+                    Z3_CXX_INCLUDE_DIRS
+                    NAMES z3.h z3++.h
+                    NO_DEFAULT_PATH
+                    PATHS ${Z3_PYTHON_ROOT}
+                    PATH_SUFFIXES libz3 z3 include)
+
+            find_library(
+                    Z3_LIBRARIES
+                    NAMES z3 libz3
+                    NO_DEFAULT_PATH
+                    PATHS ${Z3_PYTHON_ROOT}
+                    PATH_SUFFIXES lib bin)
+
+            if (Z3_CXX_INCLUDE_DIRS AND Z3_LIBRARIES)
+                message(STATUS "Found Z3 includes and libraries from Python installation.")
+                message(VERBOSE "Z3_CXX_INCLUDE_DIRS: ${Z3_CXX_INCLUDE_DIRS}")
+                message(VERBOSE "Z3_LIBRARIES: ${Z3_LIBRARIES}")
+                check_z3_version(${Z3_CXX_INCLUDE_DIRS} ${Z3_LIBRARIES})
+            endif ()
+        endif ()
+    endif ()
+endif ()
+
+if (NOT FOUND_SUITABLE_VERSION)
+    if (Z3_CXX_INCLUDE_DIRS AND Z3_LIBRARIES)
+        message(STATUS "Found include and library directories but could not find a suitable Z3 version")
+    endif ()
+    set(Z3_VERSION_STRING "0.0.0")
+endif ()
+
+find_package_handle_standard_args(
+        Z3
+        REQUIRED_VARS Z3_LIBRARIES Z3_CXX_INCLUDE_DIRS
+        VERSION_VAR Z3_VERSION_STRING)
+
+if (Z3_FOUND)
+    if (NOT TARGET z3::z3lib)
+        add_library(z3::z3lib INTERFACE IMPORTED GLOBAL)
+        target_include_directories(z3::z3lib INTERFACE ${Z3_CXX_INCLUDE_DIRS})
+        target_link_libraries(z3::z3lib INTERFACE ${Z3_LIBRARIES})
+    endif ()
+    add_compile_definitions(Z3_FOUND)
+endif ()
+
+mark_as_advanced(Z3_CXX_INCLUDE_DIRS Z3_LIBRARIES Z3_VERSION_STRING)

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -46,6 +46,7 @@ endif ()
 option(FICTION_Z3 "Find, include, and utilize the Z3 solver by Microsoft Research. It needs to be installed manually.")
 if (FICTION_Z3)
     message(STATUS "Usage of the Z3 solver was enabled. Make sure that it is installed on your system!")
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/") # include FindZ3.cmake
     set(FICTION_Z3_SEARCH_PATHS "" CACHE STRING "Hints CMake where to search for the Z3 package. Usually only necessary if Z3 cannot be found automatically.")
     # Try to locate Z3
     find_package(Z3 PATHS ${FICTION_Z3_SEARCH_PATHS})

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -47,13 +47,13 @@ option(FICTION_Z3 "Find, include, and utilize the Z3 solver by Microsoft Researc
 if (FICTION_Z3)
     message(STATUS "Usage of the Z3 solver was enabled. Make sure that it is installed on your system!")
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/") # include FindZ3.cmake
-    set(FICTION_Z3_SEARCH_PATHS "" CACHE STRING "Hints CMake where to search for the Z3 package. Usually only necessary if Z3 cannot be found automatically.")
-    # Try to locate Z3
-    find_package(Z3 PATHS ${FICTION_Z3_SEARCH_PATHS})
+
+    # Try to locate Z3 (minimum required version is 4.8.5 due to its performance improvements on the QBF solver)
+    find_package(Z3 4.8.5)
 
     if (Z3_FOUND)
         # Status update
-        message(STATUS "Found Z3 solver version: ${Z3_VERSION}")
+        message(STATUS "Found Z3 solver version: ${Z3_VERSION_STRING}")
         message(STATUS "Found Z3 library: ${Z3_LIBRARIES}")
         message(STATUS "Found Z3 include directories: ${Z3_CXX_INCLUDE_DIRS}")
 


### PR DESCRIPTION
Make use of [cda-tum/setup-z3](https://github.com/cda-tum/setup-z3) to seamlessly install Z3 in the action runners. This alleviates quite a bit of the legacy burden that came with self-compiling Z3. Consequently, the build times could be sped up significantly.

Many thanks to @burgholzer for his efforts!