### PR TITLE
:construction_worker: Enable `ccache` for GitHub Action runners

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           submodules: recursive
 
-      - name: ccache
+      - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: "ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,6 +35,14 @@ jobs:
         with:
           submodules: recursive
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: "ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}"
+          variant: ccache
+          save: true
+          max-size: 10G
+
       - name: Install pip packages
         uses: BSFishy/pip-action@v1
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build:
-
+    name: Build Docker image
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           submodules: recursive
 
-      - name: ccache
+      - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: "ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -46,6 +46,14 @@ jobs:
         with:
           submodules: recursive
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: "ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}"
+          variant: ccache
+          save: true
+          max-size: 10G
+
       - name: Setup Z3 Solver
         id: z3
         uses: cda-tum/setup-z3@v1

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           submodules: recursive
 
-      - name: ccache
+      - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: "ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -43,6 +43,14 @@ jobs:
         with:
           submodules: recursive
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: "ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}"
+          variant: ccache
+          save: true
+          max-size: 10G
+
       - name: Install pip packages
         uses: BSFishy/pip-action@v1
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,6 +36,14 @@ jobs:
         with:
           submodules: recursive
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: "sccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}"
+          variant: sccache
+          save: true
+          max-size: 10G
+
       - name: Setup Z3 Solver
         id: z3
         uses: cda-tum/setup-z3@v1
@@ -52,7 +60,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}\build
 
-        run: cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
+        run: cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF -DCACHE_OPTION="sccache"
 
       - name: Build
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}\build
 
-        run: cmake ${{github.workspace}} -G "Unix Makefiles" -A x64 -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
+        run: cmake ${{github.workspace}} -G "Unix Makefiles" -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: "ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}"
+          key: "ccache-${{matrix.os}}-${{matrix.toolset}}-${{matrix.build_type}}"
           variant: ccache
           save: true
           max-size: 10G
@@ -60,7 +60,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}\build
 
-        run: cmake ${{github.workspace}} -G "Unix Makefiles" -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
+        run: cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}\build
 
-        run: cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF -DCACHE_OPTION="sccache"
+        run: cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DCACHE_OPTION="sccache" -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,11 +36,11 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup sccache
+      - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: "sccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}"
-          variant: sccache
+          key: "ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}"
+          variant: ccache
           save: true
           max-size: 10G
 
@@ -60,7 +60,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}\build
 
-        run: cmake ${{github.workspace}} -G "Ninja" -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DCACHE_OPTION="sccache" -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
+        run: cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}\build
 
-        run: cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
+        run: cmake ${{github.workspace}} -G "Unix Makefiles" -A x64 -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}\build
 
-        run: cmake ${{github.workspace}} -G "Ninja" -A x64 -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DCACHE_OPTION="sccache" -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
+        run: cmake ${{github.workspace}} -G "Ninja" -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DCACHE_OPTION="sccache" -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}\build
 
-        run: cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DCACHE_OPTION="sccache" -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
+        run: cmake ${{github.workspace}} -G "Ninja" -A x64 -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DCACHE_OPTION="sccache" -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_Z3=ON -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build
         working-directory: ${{github.workspace}}\build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           submodules: recursive
 
-      - name: ccache
+      - name: Setup sccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: "sccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}"


### PR DESCRIPTION
Using [`hendrikmuhs/ccache-action`](https://github.com/marketplace/actions/ccache-for-gh-actions), build times of the CI jobs are significantly sped up via caching.