### PR TITLE
:bug: Fixed a bug with layout DOT drawers and a small inconsistency in the tests

### DIFF
--- a/include/fiction/io/dot_drawers.hpp
+++ b/include/fiction/io/dot_drawers.hpp
@@ -975,7 +975,7 @@ template <class Lyt, class Drawer>
 void write_dot_layout(const Lyt& lyt, const std::string& filename, const Drawer& drawer = {})
 {
     std::ofstream os{filename.c_str(), std::ofstream::out};
-    write_dot(lyt, os, drawer);
+    write_dot_layout(lyt, os, drawer);
     os.close();
 }
 

--- a/test/networks/technology_network.cpp
+++ b/test/networks/technology_network.cpp
@@ -551,9 +551,11 @@ TEST_CASE("Node functions of a technology network", "[technology-network]")
     technology_network tec{};
 
     CHECK(mockturtle::has_is_and_v<technology_network>);
+    CHECK(fiction::has_is_nand_v<technology_network>);
     CHECK(mockturtle::has_is_or_v<technology_network>);
-    CHECK(mockturtle::has_is_or_v<technology_network>);
+    CHECK(fiction::has_is_nor_v<technology_network>);
     CHECK(mockturtle::has_is_xor_v<technology_network>);
+    CHECK(fiction::has_is_xnor_v<technology_network>);
     CHECK(mockturtle::has_is_maj_v<technology_network>);
     CHECK(mockturtle::has_is_ite_v<technology_network>);
     CHECK(mockturtle::has_is_xor3_v<technology_network>);


### PR DESCRIPTION
- `write_dot_layout` called the wrong DOT drawer
- `technology_network` was not sufficiently checked for function creation traits