### PR TITLE
Bug fix: FICTION_PYTHON_BINDINGS flag was ignored

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ endif ()
 # Python Bindings
 option(FICTION_PYTHON_BINDINGS "Build fiction Python bindings" OFF)
 if (FICTION_PYTHON_BINDINGS)
-    message(STATUS "Building fiction experiments")
+    message(STATUS "Building fiction Python bindings")
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/bindings/)
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ endif ()
 
 # Python Bindings
 option(FICTION_PYTHON_BINDINGS "Build fiction Python bindings" OFF)
-if (FICTION_EXPERIMENTS)
+if (FICTION_PYTHON_BINDINGS)
     message(STATUS "Building fiction experiments")
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/bindings/)
 endif ()


### PR DESCRIPTION
As a result of the flag being ignored, the build system would not be able to find the pyfiction build target.