### PR TITLE
:construction_worker: Run CI only when necessary

### DIFF
--- a/.github/workflows/clang-tidy-review-post.yml
+++ b/.github/workflows/clang-tidy-review-post.yml
@@ -39,4 +39,9 @@ jobs:
 
       # Posts the comments
       - name: Post review comments
+        id: post-review
         uses: ZedThree/clang-tidy-review/post@v0.10.1
+
+      # If there are any comments, fail the check
+      - if: steps.post-review.outputs.total_comments > 0
+        run: exit 1

--- a/.github/workflows/clang-tidy-review-post.yml
+++ b/.github/workflows/clang-tidy-review-post.yml
@@ -2,7 +2,7 @@ name: Post Clang-Tidy Review
 
 on:
   workflow_run:
-    workflows: [ "Clang-Tidy Review" ]
+    workflows: [ 'Clang-Tidy Review' ]
     types:
       - completed
 

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -16,12 +16,12 @@ jobs:
         uses: ZedThree/clang-tidy-review@v0.10.1
         id: review
         with:
-          cmake_command: |
-            cmake . -B build \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DFICTION_CLI=ON \
-            -DFICTION_TEST=ON \
-            -DFICTION_EXPERIMENTS=ON \
+          cmake_command: >
+            cmake . -B build
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+            -DFICTION_CLI=ON
+            -DFICTION_TEST=ON
+            -DFICTION_EXPERIMENTS=ON
             -DMOCKTURTLE_EXAMPLES=OFF
           build_dir: build
           config_file: '.clang-tidy'

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -26,7 +26,7 @@ jobs:
         id: check-review-output
         uses: andstor/file-existence-action@v2.0.0
         with:
-          files: "clang-tidy-review-output.json"
+          files: 'clang-tidy-review-output.json'
           ignore_case: true
 
       # Workaround to fix an issue with non-existing review artifacts in the review posting workflow
@@ -34,8 +34,8 @@ jobs:
         if: steps.check-review-output.outputs.files_exists == 'false'
         uses: finnp/create-file-action@1.0.0
         env:
-          FILE_NAME: "clang-tidy-review-output.json"
-          FILE_DATA: "{}"
+          FILE_NAME: 'clang-tidy-review-output.json'
+          FILE_DATA: '{}'
 
       - name: Upload review artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -16,7 +16,13 @@ jobs:
         uses: ZedThree/clang-tidy-review@v0.10.1
         id: review
         with:
-          cmake_command: cmake . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_EXPERIMENTS=ON -DMOCKTURTLE_EXAMPLES=OFF
+          cmake_command: |
+            cmake . -B build \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DFICTION_CLI=ON \
+            -DFICTION_TEST=ON \
+            -DFICTION_EXPERIMENTS=ON \
+            -DMOCKTURTLE_EXAMPLES=OFF
           build_dir: build
           config_file: '.clang-tidy'
           exclude: 'libs/*, docs/*, benchmarks/*, bib/*, */catch2/*.hpp'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,11 +1,11 @@
-name: "CodeQL"
+name: CodeQL
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ 'main' ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: [ 'main' ]
   schedule:
     - cron: '30 5 * * 6'
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -62,7 +62,8 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
-        run: cmake ${{github.workspace}} \
+        run: |
+          cmake ${{github.workspace}} \
           -DCMAKE_CXX_COMPILER=${{matrix.compiler}} \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DFICTION_CLI=OFF \

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: "ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}"
+          key: '${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}'
           variant: ccache
           save: true
           max-size: 10G

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -62,7 +62,17 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
-        run: cmake ${{github.workspace}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DFICTION_CLI=OFF -DFICTION_TEST=ON -DFICTION_Z3=ON -DFICTION_ENABLE_MUGEN=ON -DFICTION_PROGRESS_BARS=OFF -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF -DENABLE_COVERAGE=ON
+        run: cmake ${{github.workspace}} \
+          -DCMAKE_CXX_COMPILER=${{matrix.compiler}} \
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -DFICTION_CLI=OFF \
+          -DFICTION_TEST=ON \
+          -DFICTION_Z3=ON \
+          -DFICTION_ENABLE_MUGEN=ON \
+          -DFICTION_PROGRESS_BARS=OFF \
+          -DMOCKTURTLE_EXAMPLES=OFF \
+          -DWARNINGS_AS_ERRORS=OFF \
+          -DENABLE_COVERAGE=ON
 
       - name: Build
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -62,17 +62,17 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
-        run: |
-          cmake ${{github.workspace}} \
-          -DCMAKE_CXX_COMPILER=${{matrix.compiler}} \
-          -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-          -DFICTION_CLI=OFF \
-          -DFICTION_TEST=ON \
-          -DFICTION_Z3=ON \
-          -DFICTION_ENABLE_MUGEN=ON \
-          -DFICTION_PROGRESS_BARS=OFF \
-          -DMOCKTURTLE_EXAMPLES=OFF \
-          -DWARNINGS_AS_ERRORS=OFF \
+        run: >
+          cmake ${{github.workspace}}
+          -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+          -DFICTION_CLI=OFF
+          -DFICTION_TEST=ON
+          -DFICTION_Z3=ON
+          -DFICTION_ENABLE_MUGEN=ON
+          -DFICTION_PROGRESS_BARS=OFF
+          -DMOCKTURTLE_EXAMPLES=OFF
+          -DWARNINGS_AS_ERRORS=OFF
           -DENABLE_COVERAGE=ON
 
       - name: Build

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,12 +17,11 @@ on:
       - '.github/workflows/docker-image.yml'
 
 jobs:
-
   build:
     name: Build Docker image
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build the Docker image
-      run: docker build --build-arg NUMBER_OF_JOBS=2 . --file Dockerfile --tag fiction:$(date +%s)
+      - uses: actions/checkout@v3
+      - name: Build the Docker image
+        run: docker build --build-arg NUMBER_OF_JOBS=2 . --file Dockerfile --tag fiction:$(date +%s)

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,9 +2,19 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ 'main' ]
+    paths:
+      - '**.hpp'
+      - '**.cpp'
+      - 'libs/**'
+      - '.github/workflows/docker-image.yml'
   pull_request:
-    branches: [ "main" ]
+    branches: [ 'main' ]
+    paths:
+      - '**.hpp'
+      - '**.cpp'
+      - 'libs/**'
+      - '.github/workflows/docker-image.yml'
 
 jobs:
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -81,7 +81,8 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
-        run: cmake ${{github.workspace}} \
+        run: |
+          cmake ${{github.workspace}} \
           -DCMAKE_CXX_COMPILER=${{matrix.compiler}} \
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
           -DFICTION_CLI=ON \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -81,7 +81,16 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
-        run: cmake ${{github.workspace}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_EXPERIMENTS=ON -DFICTION_Z3=ON -DFICTION_PROGRESS_BARS=OFF -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
+        run: cmake ${{github.workspace}} \
+          -DCMAKE_CXX_COMPILER=${{matrix.compiler}} \
+          -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
+          -DFICTION_CLI=ON \
+          -DFICTION_TEST=ON \
+          -DFICTION_EXPERIMENTS=ON \
+          -DFICTION_Z3=ON \
+          -DFICTION_PROGRESS_BARS=OFF \
+          -DMOCKTURTLE_EXAMPLES=OFF \
+          -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: "ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}"
+          key: '${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}'
           variant: ccache
           save: true
           max-size: 10G

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,12 @@
 name: macOS CI
 
-on: push
+on:
+  push:
+    paths:
+      - '**.hpp'
+      - '**.cpp'
+      - 'libs/**'
+      - '.github/workflows/macos.yml'
 
 defaults:
   run:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -81,16 +81,16 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
-        run: |
-          cmake ${{github.workspace}} \
-          -DCMAKE_CXX_COMPILER=${{matrix.compiler}} \
-          -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
-          -DFICTION_CLI=ON \
-          -DFICTION_TEST=ON \
-          -DFICTION_EXPERIMENTS=ON \
-          -DFICTION_Z3=ON \
-          -DFICTION_PROGRESS_BARS=OFF \
-          -DMOCKTURTLE_EXAMPLES=OFF \
+        run: >
+          cmake ${{github.workspace}}
+          -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
+          -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+          -DFICTION_CLI=ON
+          -DFICTION_TEST=ON
+          -DFICTION_EXPERIMENTS=ON
+          -DFICTION_Z3=ON
+          -DFICTION_PROGRESS_BARS=OFF
+          -DMOCKTURTLE_EXAMPLES=OFF
           -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -77,17 +77,17 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
-        run: |
-          cmake ${{github.workspace}} ${{matrix.cppstandard}} \
-          -DCMAKE_CXX_COMPILER=${{matrix.compiler}} \
-          -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
-          -DFICTION_CLI=ON \
-          -DFICTION_TEST=ON \
-          -DFICTION_EXPERIMENTS=ON \
-          -DFICTION_Z3=ON \
-          -DFICTION_ENABLE_MUGEN=ON \
-          -DFICTION_PROGRESS_BARS=OFF \
-          -DMOCKTURTLE_EXAMPLES=OFF \
+        run: >
+          cmake ${{github.workspace}} ${{matrix.cppstandard}}
+          -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
+          -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+          -DFICTION_CLI=ON
+          -DFICTION_TEST=ON
+          -DFICTION_EXPERIMENTS=ON
+          -DFICTION_Z3=ON
+          -DFICTION_ENABLE_MUGEN=ON
+          -DFICTION_PROGRESS_BARS=OFF
+          -DMOCKTURTLE_EXAMPLES=OFF
           -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build fiction

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -77,7 +77,17 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
-        run: cmake ${{github.workspace}} ${{matrix.cppstandard}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_EXPERIMENTS=ON -DFICTION_Z3=ON -DFICTION_ENABLE_MUGEN=ON -DFICTION_PROGRESS_BARS=OFF -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
+        run: cmake ${{github.workspace}} ${{matrix.cppstandard}} \
+          -DCMAKE_CXX_COMPILER=${{matrix.compiler}} \
+          -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
+          -DFICTION_CLI=ON \
+          -DFICTION_TEST=ON \
+          -DFICTION_EXPERIMENTS=ON \
+          -DFICTION_Z3=ON \
+          -DFICTION_ENABLE_MUGEN=ON \
+          -DFICTION_PROGRESS_BARS=OFF \
+          -DMOCKTURTLE_EXAMPLES=OFF \
+          -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build fiction
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -77,7 +77,8 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
-        run: cmake ${{github.workspace}} ${{matrix.cppstandard}} \
+        run: |
+          cmake ${{github.workspace}} ${{matrix.cppstandard}} \
           -DCMAKE_CXX_COMPILER=${{matrix.compiler}} \
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
           -DFICTION_CLI=ON \

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,6 +1,12 @@
 name: Ubuntu CI
 
-on: push
+on:
+  push:
+    paths:
+      - '**.hpp'
+      - '**.cpp'
+      - 'libs/**'
+      - '.github/workflows/ubuntu.yml'
 
 defaults:
   run:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: "ccache-${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}"
+          key: '${{matrix.os}}-${{matrix.compiler}}-${{matrix.build_type}}'
           variant: ccache
           save: true
           max-size: 10G

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,12 @@
 name: Windows CI
 
-on: push
+on:
+  push:
+    paths:
+      - '**.hpp'
+      - '**.cpp'
+      - 'libs/**'
+      - '.github/workflows/windows.yml'
 
 defaults:
   run:
@@ -18,9 +24,9 @@ jobs:
         build_type: [ Debug, Release ]
         include:
           - os: windows-2019
-            env: "Visual Studio 16 2019"
+            env: 'Visual Studio 16 2019'
           - os: windows-2022
-            env: "Visual Studio 17 2022"
+            env: 'Visual Studio 17 2022'
         exclude:
           - os: windows-2019
             toolset: v143
@@ -39,7 +45,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: "ccache-${{matrix.os}}-${{matrix.toolset}}-${{matrix.build_type}}"
+          key: '${{matrix.os}}-${{matrix.toolset}}-${{matrix.build_type}}'
           variant: ccache
           save: true
           max-size: 10G

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,14 +65,14 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{github.workspace}}\build
-        run: |
-          cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}} \
-          -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
-          -DFICTION_CLI=ON \
-          -DFICTION_TEST=ON \
-          -DFICTION_EXPERIMENTS=ON \
-          -DFICTION_Z3=ON \
-          -DMOCKTURTLE_EXAMPLES=OFF \
+        run: >
+          cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}}
+          -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+          -DFICTION_CLI=ON
+          -DFICTION_TEST=ON
+          -DFICTION_EXPERIMENTS=ON
+          -DFICTION_Z3=ON
+          -DMOCKTURTLE_EXAMPLES=OFF
           -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,7 +65,8 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{github.workspace}}\build
-        run: cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}} \
+        run: |
+          cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}} \
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
           -DFICTION_CLI=ON \
           -DFICTION_TEST=ON \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,7 +65,14 @@ jobs:
 
       - name: Configure CMake
         working-directory: ${{github.workspace}}\build
-        run: cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DFICTION_CLI=ON -DFICTION_TEST=ON -DFICTION_EXPERIMENTS=ON -DFICTION_Z3=ON -DMOCKTURTLE_EXAMPLES=OFF -DWARNINGS_AS_ERRORS=OFF
+        run: cmake ${{github.workspace}} -G "${{matrix.env}}" -A x64 -T ${{matrix.toolset}} \
+          -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
+          -DFICTION_CLI=ON \
+          -DFICTION_TEST=ON \
+          -DFICTION_EXPERIMENTS=ON \
+          -DFICTION_Z3=ON \
+          -DMOCKTURTLE_EXAMPLES=OFF \
+          -DWARNINGS_AS_ERRORS=OFF
 
       - name: Build
         working-directory: ${{github.workspace}}\build


### PR DESCRIPTION
This PR adapts the CI workflows such that they are only run when files have changed which could affect their outcome. Thereby, less time should be spent running redundant CIs.