### PR TITLE
:construction_worker: Added a ClangFormat linter workflow

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,48 @@
+name: ClangFormat Linter
+
+on:
+  push:
+    branches: [ 'main' ]
+  pull_request:
+    branches: [ 'main' ]
+
+jobs:
+  clangformat:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone Repository (for push events)
+        if: ${{ github.event_name == 'push' }}
+        # regular checkout
+        uses: actions/checkout@v3
+        with:
+        submodules: recursive
+
+      - name: Clone Repository (for PR events)
+        if: ${{ github.event_name == 'pull_request' }}
+        # PR checkout
+        uses: actions/checkout@v3
+        with:
+          # checkout the repository the branch is coming from
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          # prevent checkout in detached head state
+          ref: ${{ github.event.pull_request.head.ref }}
+          submodules: recursive
+
+      - name: Run ClangFormat
+        uses: DoozyX/clang-format-lint-action@v0.15
+        with:
+          source: 'include test experiments'
+          exclude: '*/catch2/*.hpp'
+          extensions: 'hpp,cpp'
+          clangFormatVersion: 15
+          inplace: True
+
+      - uses: EndBug/add-and-commit@v9
+        with:
+          add: 'include test experiments'
+          author_name: ClangFormat
+          commit: '--signoff'
+          message: ':art: ClangFormat changes'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -16,7 +16,7 @@ jobs:
         # regular checkout
         uses: actions/checkout@v3
         with:
-        submodules: recursive
+          submodules: recursive
 
       - name: Clone Repository (for PR events)
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -41,8 +41,9 @@ jobs:
       - uses: EndBug/add-and-commit@v9
         with:
           add: 'include test experiments'
-          author_name: ClangFormat
           commit: '--signoff'
           message: ':art: ClangFormat changes'
+          author_name: ClangFormat
+          author_email: ClangFormat@users.noreply.github.com
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a linter using [`ClangFormat`](https://clang.llvm.org/docs/ClangFormat.html). It automatically applies proposed changes to PRs and pushes to `main`.