### PR TITLE
:bug: Fixed a bug in SAT-based graph coloring

### DIFF
--- a/include/fiction/algorithms/graph/graph_coloring.hpp
+++ b/include/fiction/algorithms/graph/graph_coloring.hpp
@@ -227,7 +227,10 @@ class sat_coloring_handler
 
         if (ps.clique_size_color_frequency)
         {
-            color_frequency_equal_to_largest_clique_size(k_color_instance);
+            if (!all_cliques_are_equal_in_size())
+            {
+                color_frequency_equal_to_largest_clique_size(k_color_instance);
+            }
         }
 
         return {check_sat(k_color_instance), k_color_instance};
@@ -467,6 +470,12 @@ class sat_coloring_handler
                                     bill::lit_type{instance->variables[{v2, c}], bill::negative_polarity}}});
                           }
                       });
+    }
+
+    [[nodiscard]] bool all_cliques_are_equal_in_size() const noexcept
+    {
+        return std::all_of(ps.cliques.cbegin(), ps.cliques.cend(),
+                           [this](const auto& clique) { return clique.size() == q; });
     }
 
     void color_frequency_equal_to_largest_clique_size(const solver_instance_ptr& instance) const

--- a/test/algorithms/graph/graph_coloring.cpp
+++ b/test/algorithms/graph/graph_coloring.cpp
@@ -41,7 +41,7 @@ void check_sat_search_tactics(const Graph& graph, const std::size_t expected_chr
 {
     determine_vertex_coloring_stats pst{};
 
-    SECTION("linear ascending search")
+    SECTION("linearly ascending search")
     {
         sat_params.sat_search_tactic = graph_coloring_sat_search_tactic::LINEARLY_ASCENDING;
 
@@ -50,7 +50,7 @@ void check_sat_search_tactics(const Graph& graph, const std::size_t expected_chr
 
         check_statistics_with_exact_chromatic_number(pst, expected_chromatic_number);
     }
-    SECTION("linear descending search")
+    SECTION("linearly descending search")
     {
         sat_params.sat_search_tactic = graph_coloring_sat_search_tactic::LINEARLY_DESCENDING;
 
@@ -275,7 +275,7 @@ Graph create_complete_graph(std::vector<typename Graph::vertex_id_type>& vertice
 {
     Graph k{};
 
-    std::for_each(vertices.cbegin(), vertices.cend(), [&k](const auto v) { k.insert_vertex(v, {}); });
+    std::for_each(vertices.cbegin(), vertices.cend(), [&k](const auto& v) { k.insert_vertex(v, {}); });
     combinations::for_each_combination(vertices.begin(), vertices.begin() + 2, vertices.end(),
                                        [&k](const auto begin, [[maybe_unused]] const auto end)
                                        {

--- a/test/algorithms/physical_design/color_routing.cpp
+++ b/test/algorithms/physical_design/color_routing.cpp
@@ -170,3 +170,32 @@ TEST_CASE("Routing with crossings", "[color-routing]")
         check_color_routing(spec_layout, impl_layout, objectives, ps);
     }
 }
+
+TEST_CASE("Routing failure", "[color-routing]")
+{
+    cart_gate_clk_lyt layout{{3, 4, 1}, twoddwave_clocking<cart_gate_clk_lyt>()};
+
+    const auto x1 = layout.create_pi("x1", {0, 1});
+    const auto x2 = layout.create_pi("x2", {1, 0});
+
+    layout.create_pi("x3", {0, 2});
+    layout.create_and(x1, x2, {1, 3});
+
+    const std::vector<routing_objective<cart_gate_clk_lyt>> objectives{{{0, 1}, {1, 3}}, {{1, 0}, {1, 3}}};
+
+    color_routing_params ps{};
+    ps.crossings = true;
+
+    SECTION("MCS")
+    {
+        ps.engine = graph_coloring_engine::MCS;
+        // routing should fail
+        CHECK(!color_routing(layout, objectives, ps));
+    }
+    SECTION("SAT")
+    {
+        ps.engine = graph_coloring_engine::SAT;
+        // routing should fail
+        CHECK(!color_routing(layout, objectives, ps));
+    }
+}


### PR DESCRIPTION
This bug occurred when clique information was provided for mutex cliques of the same size. The SAT solver would then not be able to find a proper coloring anymore and the attempt would fail.

Many thanks to @simon1hofmann for reporting!