### PR TITLE
:bug: Fixed a bug in `color_routing` 

### DIFF
--- a/include/fiction/algorithms/graph/generate_edge_intersection_graph.hpp
+++ b/include/fiction/algorithms/graph/generate_edge_intersection_graph.hpp
@@ -109,8 +109,8 @@ class generate_edge_intersection_graph_impl
                           else
                           {
                               // enumerate k paths for the current objective
-                              obj_paths = yen_k_shortest_paths<clk_path>(obstruction_layout{layout},
-                                                                         {obj.source, obj.target}, *ps.path_limit);
+                              obj_paths = yen_k_shortest_paths<clk_path>(
+                                  obstruction_layout{layout}, {obj.source, obj.target}, *ps.path_limit, {ps.crossings});
                           }
 
                           // assign a unique label to each path and create a corresponding node in the graph

--- a/test/algorithms/physical_design/color_routing.cpp
+++ b/test/algorithms/physical_design/color_routing.cpp
@@ -159,15 +159,33 @@ TEST_CASE("Routing with crossings", "[color-routing]")
     color_routing_params ps{};
     ps.crossings = true;
 
-    SECTION("MCS")
+    SECTION("Without path limit")
     {
-        ps.engine = graph_coloring_engine::MCS;
-        check_color_routing(spec_layout, impl_layout, objectives, ps);
+        SECTION("MCS")
+        {
+            ps.engine = graph_coloring_engine::MCS;
+            check_color_routing(spec_layout, impl_layout, objectives, ps);
+        }
+        SECTION("SAT")
+        {
+            ps.engine = graph_coloring_engine::SAT;
+            check_color_routing(spec_layout, impl_layout, objectives, ps);
+        }
     }
-    SECTION("SAT")
+    SECTION("With path limit")
     {
-        ps.engine = graph_coloring_engine::SAT;
-        check_color_routing(spec_layout, impl_layout, objectives, ps);
+        ps.path_limit = 2;
+
+        SECTION("MCS")
+        {
+            ps.engine = graph_coloring_engine::MCS;
+            check_color_routing(spec_layout, impl_layout, objectives, ps);
+        }
+        SECTION("SAT")
+        {
+            ps.engine = graph_coloring_engine::SAT;
+            check_color_routing(spec_layout, impl_layout, objectives, ps);
+        }
     }
 }
 


### PR DESCRIPTION
The bug prevented crossing flags from being passed through to Yen's algorithm when a path limit was specified. Many thanks to @simon1hofmann for reporting!