### PR TITLE
:bug: Added additional checks for `is_obstructed_connection` to ensure proper handling of crossing cases

### DIFF
--- a/include/fiction/layouts/cartesian_layout.hpp
+++ b/include/fiction/layouts/cartesian_layout.hpp
@@ -597,7 +597,7 @@ class cartesian_layout
      */
     [[nodiscard]] constexpr bool is_crossing_layer(const OffsetCoordinateType& c) const noexcept
     {
-        return c.z > 0;
+        return c.z > 0ull;
     }
     /**
      * Returns whether the given coordinate is located within the layout bounds.

--- a/include/fiction/layouts/obstruction_layout.hpp
+++ b/include/fiction/layouts/obstruction_layout.hpp
@@ -137,7 +137,18 @@ class obstruction_layout<Lyt, false> : public Lyt
     [[nodiscard]] bool is_obstructed_connection(const typename Lyt::coordinate& src,
                                                 const typename Lyt::coordinate& tgt) const noexcept
     {
-        return strg->obstructed_connections.count({src, tgt}) > 0;
+        if (strg->obstructed_connections.count({src, tgt}) > 0)
+        {
+            return true;
+        }
+        if constexpr (is_gate_level_layout_v<Lyt>)
+        {
+            return Lyt::is_incoming_signal(tgt, static_cast<mockturtle::signal<Lyt>>(src));
+        }
+
+        // more implementations go here
+
+        return false;
     }
 
   private:

--- a/test/algorithms/physical_design/color_routing.cpp
+++ b/test/algorithms/physical_design/color_routing.cpp
@@ -246,3 +246,50 @@ TEST_CASE("Routing failure 2", "[color-routing]")
         CHECK(!color_routing(layout, objectives, ps));
     }
 }
+
+TEST_CASE("Routing failure 3", "[color-routing]")
+{
+    cart_gate_clk_lyt layout{{2, 4, 1}, twoddwave_clocking<cart_gate_clk_lyt>()};
+
+    const auto x1 = layout.create_pi("x1", {0, 0});
+    const auto w1 = layout.create_buf(x1, {0, 1});
+    const auto x2 = layout.create_pi("x2", {1, 0});
+    const auto w2 = layout.create_buf(x2, {1, 1});
+    const auto a1 = layout.create_and(w1, w2, {2, 1});
+
+    color_routing_params ps{};
+    ps.crossings = true;
+
+    SECTION("Wires without connections")
+    {
+        layout.move_node(layout.get_node(a1), {2, 1});
+
+        const std::vector<routing_objective<cart_gate_clk_lyt>> objectives{{{0, 1}, {2, 1}}, {{1, 1}, {2, 1}}};
+
+        SECTION("k = 3")
+        {
+            ps.path_limit = 3;
+            CHECK(!color_routing(layout, objectives, ps));
+        }
+        SECTION("no path limit")
+        {
+            CHECK(!color_routing(layout, objectives, ps));
+        }
+    }
+    SECTION("Goal node behind wire crossing")
+    {
+        layout.move_node(layout.get_node(a1), {2, 1}, {w2});
+
+        const std::vector<routing_objective<cart_gate_clk_lyt>> objectives{{{0, 1}, {2, 1}}, {{1, 1}, {2, 1}}};
+
+        SECTION("k = 3")
+        {
+            ps.path_limit = 3;
+            CHECK(!color_routing(layout, objectives, ps));
+        }
+        SECTION("no path limit")
+        {
+            CHECK(!color_routing(layout, objectives, ps));
+        }
+    }
+}

--- a/test/layouts/obstruction_layout.cpp
+++ b/test/layouts/obstruction_layout.cpp
@@ -308,12 +308,15 @@ TEST_CASE("Connection obstruction", "[obstruction-layout]")
 
         obstruction_layout obstr_lyt{lyt};
 
-        obstr_lyt.foreach_coordinate(
-            [&obstr_lyt](const auto& c)
-            {
-                obstr_lyt.foreach_adjacent_coordinate(c, [&obstr_lyt, &c](const auto& ac)
-                                                      { CHECK(!obstr_lyt.is_obstructed_connection(c, ac)); });
-            });
+        CHECK(obstr_lyt.is_obstructed_connection({1, 1}, {2, 1}));
+        CHECK(obstr_lyt.is_obstructed_connection({2, 0}, {2, 1}));
+        CHECK(obstr_lyt.is_obstructed_connection({3, 1}, {2, 1}));
+
+        CHECK(obstr_lyt.is_obstructed_connection({1, 1}, {1, 0}));
+        CHECK(obstr_lyt.is_obstructed_connection({2, 0}, {1, 0}));
+
+        CHECK(obstr_lyt.is_obstructed_connection({2, 1}, {2, 2}));
+        CHECK(obstr_lyt.is_obstructed_connection({1, 0}, {0, 0}));
 
         // add artificial obstruction
         obstr_lyt.obstruct_connection({0, 0}, {0, 1});
@@ -321,7 +324,6 @@ TEST_CASE("Connection obstruction", "[obstruction-layout]")
         obstr_lyt.obstruct_connection({2, 4}, {4, 0});
 
         CHECK(obstr_lyt.is_obstructed_connection({0, 0}, {0, 1}));
-        CHECK(!obstr_lyt.is_obstructed_connection({1, 0}, {0, 0}));
         CHECK(obstr_lyt.is_obstructed_connection({2, 2}, {2, 3}));
         CHECK(!obstr_lyt.is_obstructed_connection({2, 3}, {2, 2}));
         CHECK(obstr_lyt.is_obstructed_connection({2, 4}, {4, 0}));
@@ -335,7 +337,6 @@ TEST_CASE("Connection obstruction", "[obstruction-layout]")
         obstr_lyt.clear_obstructed_connections();
 
         CHECK(!obstr_lyt.is_obstructed_connection({0, 0}, {0, 1}));
-        CHECK(!obstr_lyt.is_obstructed_connection({1, 0}, {0, 0}));
         CHECK(!obstr_lyt.is_obstructed_connection({2, 2}, {2, 3}));
         CHECK(!obstr_lyt.is_obstructed_connection({2, 3}, {2, 2}));
         CHECK(!obstr_lyt.is_obstructed_connection({2, 4}, {4, 0}));


### PR DESCRIPTION
`obstruction_layout` was not properly tuned to gate-level layouts in the `is_obstructed_connection` case. This has been fixed.