### PR TITLE
:art: Small inconsistency fix

### DIFF
--- a/include/fiction/algorithms/simulation/sidb/sidb_simulation_parameters.hpp
+++ b/include/fiction/algorithms/simulation/sidb/sidb_simulation_parameters.hpp
@@ -32,10 +32,11 @@ struct sidb_simulation_parameters
      * @param b lattice constant.
      * @param c lattice constant.
      */
-    explicit sidb_simulation_parameters(const uint8_t base_number = 3, const double mu_minus = -0.32,
-                                        const double relative_permittivity = 5.6,
-                                        const double screening_distance = 5.0 * 1E-9, const double a = 3.84 * 1E-10,
-                                        const double b = 7.68 * 1E-10, const double c = 2.25 * 1E-10) :
+    constexpr explicit sidb_simulation_parameters(const uint8_t base_number = 3, const double mu_minus = -0.32,
+                                                  const double relative_permittivity = 5.6,
+                                                  const double screening_distance    = 5.0 * 1E-9,
+                                                  const double a = 3.84 * 1E-10, const double b = 7.68 * 1E-10,
+                                                  const double c = 2.25 * 1E-10) :
             lat_a{a},
             lat_b{b},
             lat_c{c},

--- a/include/fiction/technology/sidb_nm_position.hpp
+++ b/include/fiction/technology/sidb_nm_position.hpp
@@ -15,13 +15,15 @@ namespace fiction
 {
 
 /**
- * Computes the position of a cell in nanometers.
+ * Computes the position of a cell in nanometers from the layout origin.
  *
+ * @tparam Lyt The layout type.
+ * @param sp The simulation parameters (required for the lattice constants).
  * @param c The cell to compute the position for.
- * @return A pair of double values representing the `(x,y)` position of the cell in nanometers.
+ * @return A pair representing the `(x,y)` position of `c` in nanometers from the layout origin.
  */
 template <typename Lyt>
-std::pair<double, double> sidb_nm_position(const sidb_simulation_parameters& sp, const cell<Lyt>& c) noexcept
+constexpr std::pair<double, double> sidb_nm_position(const sidb_simulation_parameters& sp, const cell<Lyt>& c) noexcept
 {
     static_assert(has_siqad_coord_v<Lyt>, "Lyt is not based on SiQAD coordinates");
 


### PR DESCRIPTION
Enabled `constexpr` and added missing documentation.