### PR TITLE
:bug: Fixed accessing non-existing variables in `potential_between_sidbs`

### DIFF
--- a/include/fiction/technology/charge_distribution_surface.hpp
+++ b/include/fiction/technology/charge_distribution_surface.hpp
@@ -447,16 +447,16 @@ class charge_distribution_surface<Lyt, false> : public Lyt
     [[nodiscard]] double potential_between_sidbs(const typename Lyt::cell& c1,
                                                  const typename Lyt::cell& c2) const noexcept
     {
-        const auto index1 = cell_to_index(c1);
-        const auto index2 = cell_to_index(c2);
+        const auto index1 = static_cast<std::size_t>(cell_to_index(c1));
+        const auto index2 = static_cast<std::size_t>(cell_to_index(c2));
 
         if (strg->dist_mat[index1][index2] == 0)
         {
             return 0.0;
         }
 
-        return (strg->sim_params.k / strg->dist_mat[index1][index2] *
-                std::exp(-strg->dist_mat[index1][index2] / strg->sim_params.lambda_tf) *
+        return (strg->phys_params.k / strg->dist_mat[index1][index2] *
+                std::exp(-strg->dist_mat[index1][index2] / strg->phys_params.lambda_tf) *
                 physical_constants::ELECTRIC_CHARGE);
     }
     /**


### PR DESCRIPTION
The function `potential_between_sidbs` in `charge_distribution_surface` was accessing a non-existing variable, which caused compilation to fail if this function was called. This PR fixes the behavior.