### PR TITLE
:adhesive_bandage: Renamed functions to more appropriately reflect their role

### DIFF
--- a/include/fiction/technology/charge_distribution_surface.hpp
+++ b/include/fiction/technology/charge_distribution_surface.hpp
@@ -395,9 +395,9 @@ class charge_distribution_surface<Lyt, false> : public Lyt
      *
      * @param c1 The first cell
      * @param c2 The second cell
-     * @return The potential between `c1` and `c2`.
+     * @return The electrostatic potential between `c1` and `c2`.
      */
-    [[nodiscard]] double get_electrostatic_potential(const typename Lyt::cell& c1,
+    [[nodiscard]] double get_potential_between_sidbs(const typename Lyt::cell& c1,
                                                      const typename Lyt::cell& c2) const noexcept
     {
         if (const auto index1 = cell_to_index(c1), index2 = cell_to_index(c2); (index1 != -1) && (index2 != -1))

--- a/test/technology/charge_distribution_surface.cpp
+++ b/test/technology/charge_distribution_surface.cpp
@@ -130,8 +130,8 @@ TEMPLATE_TEST_CASE(
         CHECK(charge_layout.potential_between_sidbs({5, 4}, {5, 4}) == 0.0);
         CHECK(charge_layout.potential_between_sidbs({5, 4}, {5, 6}) > 0);
         CHECK(charge_layout.potential_between_sidbs({5, 5}, {5, 6}) > 0);
-        CHECK(charge_layout.potential_between_sidbs({5, 6}, {5, 5}) ==
-              charge_layout.potential_between_sidbs({5, 5}, {5, 6}));
+        CHECK(std::abs(charge_layout.potential_between_sidbs({5, 6}, {5, 5}) -
+                       charge_layout.potential_between_sidbs({5, 5}, {5, 6})) < physical_constants::POP_STABILITY_ERR);
         // read SiDBs' charge states
         CHECK(charge_layout.get_charge_state({5, 4}) == sidb_charge_state::POSITIVE);
         CHECK(charge_layout.get_charge_state({5, 5}) == sidb_charge_state::POSITIVE);
@@ -211,8 +211,9 @@ TEMPLATE_TEST_CASE(
         CHECK(charge_layout.get_potential_between_sidbs({1, 8, 0}, {1, 8, 0}) == 0.0);
         CHECK(charge_layout.get_potential_between_sidbs({1, 10, 1}, {1, 10, 1}) == 0.0);
         CHECK((charge_layout.get_potential_between_sidbs({1, 8, 0}, {0, 0, 0}) - 0.0121934043) < 0.00000001);
-        CHECK(charge_layout.get_potential_between_sidbs({0, 0, 0}, {1, 10, 1}) ==
-              charge_layout.get_potential_between_sidbs({1, 10, 1}, {0, 0, 0}));
+        CHECK(std::abs(charge_layout.get_potential_between_sidbs({0, 0, 0}, {1, 10, 1}) -
+                       charge_layout.get_potential_between_sidbs({1, 10, 1}, {0, 0, 0})) <
+              physical_constants::POP_STABILITY_ERR);
         CHECK(charge_layout.get_potential_between_sidbs({0, 0, 0}, {1, 8, 0}) >
               charge_layout.get_potential_between_sidbs({1, 10, 1}, {0, 0, 0}));
     }

--- a/test/technology/charge_distribution_surface.cpp
+++ b/test/technology/charge_distribution_surface.cpp
@@ -199,14 +199,14 @@ TEMPLATE_TEST_CASE(
         lyt.assign_cell_type({1, 10, 1}, TestType::cell_type::NORMAL);
         charge_distribution_surface charge_layout{lyt, sidb_simulation_parameters{}};
 
-        CHECK(charge_layout.get_electrostatic_potential({0, 0, 0}, {0, 0, 0}) == 0.0);
-        CHECK(charge_layout.get_electrostatic_potential({1, 8, 0}, {1, 8, 0}) == 0.0);
-        CHECK(charge_layout.get_electrostatic_potential({1, 10, 1}, {1, 10, 1}) == 0.0);
-        CHECK((charge_layout.get_electrostatic_potential({1, 8, 0}, {0, 0, 0}) - 0.0121934043) < 0.00000001);
-        CHECK(charge_layout.get_electrostatic_potential({0, 0, 0}, {1, 10, 1}) ==
-              charge_layout.get_electrostatic_potential({1, 10, 1}, {0, 0, 0}));
-        CHECK(charge_layout.get_electrostatic_potential({0, 0, 0}, {1, 8, 0}) >
-              charge_layout.get_electrostatic_potential({1, 10, 1}, {0, 0, 0}));
+        CHECK(charge_layout.get_potential_between_sidbs({0, 0, 0}, {0, 0, 0}) == 0.0);
+        CHECK(charge_layout.get_potential_between_sidbs({1, 8, 0}, {1, 8, 0}) == 0.0);
+        CHECK(charge_layout.get_potential_between_sidbs({1, 10, 1}, {1, 10, 1}) == 0.0);
+        CHECK((charge_layout.get_potential_between_sidbs({1, 8, 0}, {0, 0, 0}) - 0.0121934043) < 0.00000001);
+        CHECK(charge_layout.get_potential_between_sidbs({0, 0, 0}, {1, 10, 1}) ==
+              charge_layout.get_potential_between_sidbs({1, 10, 1}, {0, 0, 0}));
+        CHECK(charge_layout.get_potential_between_sidbs({0, 0, 0}, {1, 8, 0}) >
+              charge_layout.get_potential_between_sidbs({1, 10, 1}, {0, 0, 0}));
     }
     //
     SECTION("Local Potential")

--- a/test/technology/charge_distribution_surface.cpp
+++ b/test/technology/charge_distribution_surface.cpp
@@ -124,7 +124,15 @@ TEMPLATE_TEST_CASE(
         // all SiDBs' charge states are set to positive
         charge_layout.set_all_charge_states(sidb_charge_state::POSITIVE);
         //
-        //        // read SiDBs' charge states
+        //
+        // calculate potential between two sidbs (charge sign not included)
+        CHECK(charge_layout.potential_between_sidbs({5, 4}, {5, 5}) > 0);
+        CHECK(charge_layout.potential_between_sidbs({5, 4}, {5, 4}) == 0.0);
+        CHECK(charge_layout.potential_between_sidbs({5, 4}, {5, 6}) > 0);
+        CHECK(charge_layout.potential_between_sidbs({5, 5}, {5, 6}) > 0);
+        CHECK(charge_layout.potential_between_sidbs({5, 6}, {5, 5}) ==
+              charge_layout.potential_between_sidbs({5, 5}, {5, 6}));
+        // read SiDBs' charge states
         CHECK(charge_layout.get_charge_state({5, 4}) == sidb_charge_state::POSITIVE);
         CHECK(charge_layout.get_charge_state({5, 5}) == sidb_charge_state::POSITIVE);
         CHECK(charge_layout.get_charge_state({5, 6}) == sidb_charge_state::POSITIVE);


### PR DESCRIPTION
## Description

In this PR, one function is renamed to appropriately reflect its role. Additionally, missing tests for ``potential_between_sidbs`` are added. 


## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
