### PR TITLE
:bug: Prevent manually declared layout obstructions to be cleared by the application of Yen's Algorithm

### DIFF
--- a/include/fiction/algorithms/path_finding/k_shortest_paths.hpp
+++ b/include/fiction/algorithms/path_finding/k_shortest_paths.hpp
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <cstdint>
 #include <iterator>
+#include <utility>
 #include <vector>
 
 namespace fiction
@@ -51,7 +52,7 @@ class yen_k_shortest_paths_impl
                          unit_cost_functor<obstruction_layout<Lyt>, uint8_t>(), ps.astar_params));
     }
 
-    path_collection<Path> run()
+    path_collection<Path> run() noexcept
     {
         assert(!objective.source.is_dead() && !objective.target.is_dead() &&
                "Neither source nor target coordinate can be dead");
@@ -87,6 +88,8 @@ class yen_k_shortest_paths_impl
                     {
                         // block the connection that was already used in the previous shortest path
                         layout.obstruct_connection(p[i], p[i + 1]);
+                        // store connection for later clearing
+                        temporarily_obstructed_connections.push_back({p[i], p[i + 1]});
                     }
                 }
 
@@ -98,6 +101,8 @@ class yen_k_shortest_paths_impl
                     {
                         // block them from further exploration
                         layout.obstruct_coordinate(root);
+                        // store coordinate for later clearing
+                        temporarily_obstructed_coordinates.push_back(root);
                     }
                 }
 
@@ -124,8 +129,7 @@ class yen_k_shortest_paths_impl
                 }
 
                 // clear obstructions again (prepare for the next potential path)
-                layout.clear_obstructed_coordinates();
-                layout.clear_obstructed_connections();
+                reset_temporary_obstructions();
             }
 
             // if there were no spur paths or if all spur paths have been added to k_shortest_paths already
@@ -174,6 +178,14 @@ class yen_k_shortest_paths_impl
      */
     path_set<Path> shortest_path_candidates{};
     /**
+     * A temporary storage for coordinates that are obstructed during the algorithm.
+     */
+    std::vector<coordinate<Lyt>> temporarily_obstructed_coordinates{};
+    /**
+     * A temporary storage for coordinates that are obstructed during the algorithm.
+     */
+    std::vector<std::pair<coordinate<Lyt>, coordinate<Lyt>>> temporarily_obstructed_connections{};
+    /**
      * Computes the cost of a path. This function can be adjusted to fetch paths of differing costs.
      *
      * Currently, the cost is equal to its length.
@@ -184,6 +196,23 @@ class yen_k_shortest_paths_impl
     static std::size_t path_cost(const Path& p) noexcept
     {
         return p.size();
+    }
+    /**
+     * Resets all temporary obstructions.
+     */
+    void reset_temporary_obstructions() noexcept
+    {
+        for (const auto& c : temporarily_obstructed_coordinates)
+        {
+            layout.clear_obstructed_coordinate(c);
+        }
+        for (const auto& c : temporarily_obstructed_connections)
+        {
+            layout.clear_obstructed_connection(c.first, c.second);
+        }
+
+        temporarily_obstructed_coordinates.clear();
+        temporarily_obstructed_connections.clear();
     }
 };
 

--- a/include/fiction/layouts/obstruction_layout.hpp
+++ b/include/fiction/layouts/obstruction_layout.hpp
@@ -91,6 +91,27 @@ class obstruction_layout<Lyt, false> : public Lyt
         strg->obstructed_connections.insert({src, tgt});
     }
     /**
+     * Clears the obstruction status of the given coordinate `c` if the obstruction was manually marked via
+     * `obstruct_coordinate`.
+     *
+     * @param c Coordinate to clear.
+     */
+    void clear_obstructed_coordinate(const typename Lyt::coordinate& c) noexcept
+    {
+        strg->obstructed_coordinates.erase(c);
+    }
+    /**
+     * Clears the obstruction status of the connection from coordinate `src` to coordinate `tgt` if the obstruction was
+     * manually marked via `obstruct_connection`.
+     *
+     * @param src Source coordinate.
+     * @param tgt Target coordinate.
+     */
+    void clear_obstructed_connection(const typename Lyt::coordinate& src, const typename Lyt::coordinate& tgt) noexcept
+    {
+        strg->obstructed_connections.erase({src, tgt});
+    }
+    /**
      * Clears all obstructed coordinates that were manually marked via `obstruct_coordinate`.
      */
     void clear_obstructed_coordinates() noexcept

--- a/test/layouts/obstruction_layout.cpp
+++ b/test/layouts/obstruction_layout.cpp
@@ -120,6 +120,18 @@ TEST_CASE("Coordinate obstruction", "[obstruction-layout]")
         CHECK(obstr_lyt.is_obstructed_coordinate({3, 0}));
         CHECK(obstr_lyt.is_obstructed_coordinate({4, 0}));
 
+        // remove some artificial obstructions
+        obstr_lyt.clear_obstructed_coordinate({0, 0});
+        obstr_lyt.clear_obstructed_coordinate({1, 0});
+        obstr_lyt.clear_obstructed_coordinate({2, 0});
+
+        CHECK(!obstr_lyt.is_obstructed_coordinate({0, 0}));
+        CHECK(!obstr_lyt.is_obstructed_coordinate({1, 0}));
+        CHECK(!obstr_lyt.is_obstructed_coordinate({2, 0}));
+        CHECK(obstr_lyt.is_obstructed_coordinate({3, 0}));
+        CHECK(obstr_lyt.is_obstructed_coordinate({4, 0}));
+
+        // remove all obstructions
         obstr_lyt.clear_obstructed_coordinates();
 
         CHECK(!obstr_lyt.is_obstructed_coordinate({0, 0}));
@@ -161,6 +173,24 @@ TEST_CASE("Coordinate obstruction", "[obstruction-layout]")
         CHECK(!obstr_lyt.is_obstructed_coordinate({3, 0}));
         CHECK(obstr_lyt.is_obstructed_coordinate({3, 2}));
 
+        // remove some manually added obstructions
+        obstr_lyt.clear_obstructed_coordinate({0, 1});
+        obstr_lyt.clear_obstructed_coordinate({1, 2});
+
+        CHECK(!obstr_lyt.is_obstructed_coordinate({0, 1}));
+        CHECK(!obstr_lyt.is_obstructed_coordinate({1, 2}));
+        CHECK(obstr_lyt.is_obstructed_coordinate({3, 2}));
+
+        // removing an obstruction that was not added manually should not change anything
+        obstr_lyt.clear_obstructed_coordinate({1, 1});
+        obstr_lyt.clear_obstructed_coordinate({2, 0});
+        obstr_lyt.clear_obstructed_coordinate({3, 1});
+
+        CHECK(obstr_lyt.is_obstructed_coordinate({1, 1}));
+        CHECK(obstr_lyt.is_obstructed_coordinate({2, 0}));
+        CHECK(obstr_lyt.is_obstructed_coordinate({3, 1}));
+
+        // remove all obstructions
         obstr_lyt.clear_obstructed_coordinates();
 
         CHECK(!obstr_lyt.is_obstructed_coordinate({0, 1}));
@@ -231,6 +261,35 @@ TEST_CASE("Coordinate obstruction", "[obstruction-layout]")
         CHECK(!obstr_lyt.is_obstructed_coordinate({4, 3}));
         CHECK(!obstr_lyt.is_obstructed_coordinate({4, 4}));
 
+        // remove some artificial obstructions
+        obstr_lyt.clear_obstructed_coordinate({0, 0});
+        obstr_lyt.clear_obstructed_coordinate({0, 1});
+        obstr_lyt.clear_obstructed_coordinate({0, 3});
+        obstr_lyt.clear_obstructed_coordinate({0, 4});
+
+        CHECK(!obstr_lyt.is_obstructed_coordinate({0, 0}));
+        CHECK(!obstr_lyt.is_obstructed_coordinate({0, 1}));
+        CHECK(!obstr_lyt.is_obstructed_coordinate({0, 3}));
+        CHECK(!obstr_lyt.is_obstructed_coordinate({0, 4}));
+        CHECK(obstr_lyt.is_obstructed_coordinate({1, 0}));
+        CHECK(obstr_lyt.is_obstructed_coordinate({1, 1}));
+        CHECK(obstr_lyt.is_obstructed_coordinate({1, 3}));
+        CHECK(obstr_lyt.is_obstructed_coordinate({1, 4}));
+
+        // removing an obstruction that was not added manually should not change anything
+        obstr_lyt.clear_obstructed_coordinate({0, 2});
+        obstr_lyt.clear_obstructed_coordinate({2, 4});
+        obstr_lyt.clear_obstructed_coordinate({2, 0});
+        obstr_lyt.clear_obstructed_coordinate({2, 1});
+        obstr_lyt.clear_obstructed_coordinate({2, 2});
+
+        CHECK(obstr_lyt.is_obstructed_coordinate({0, 2}));
+        CHECK(obstr_lyt.is_obstructed_coordinate({2, 4}));
+        CHECK(obstr_lyt.is_obstructed_coordinate({2, 0}));
+        CHECK(obstr_lyt.is_obstructed_coordinate({2, 1}));
+        CHECK(obstr_lyt.is_obstructed_coordinate({2, 2}));
+
+        // remove all artificial obstructions
         obstr_lyt.clear_obstructed_coordinates();
 
         CHECK(!obstr_lyt.is_obstructed_coordinate({0, 0}));
@@ -286,6 +345,14 @@ TEST_CASE("Connection obstruction", "[obstruction-layout]")
         CHECK(!obstr_lyt.is_obstructed_connection({3, 3}, {2, 2}));
         CHECK(!obstr_lyt.is_obstructed_connection({3, 3}, {2, 3}));
 
+        // remove some artificial obstructions
+        obstr_lyt.clear_obstructed_connection({0, 0}, {0, 1});
+
+        CHECK(!obstr_lyt.is_obstructed_connection({0, 0}, {0, 1}));
+        CHECK(obstr_lyt.is_obstructed_connection({2, 2}, {2, 3}));
+        CHECK(obstr_lyt.is_obstructed_connection({2, 4}, {4, 0}));
+
+        // remove all artificial obstructions
         obstr_lyt.clear_obstructed_connections();
 
         CHECK(!obstr_lyt.is_obstructed_connection({0, 0}, {0, 1}));
@@ -334,6 +401,23 @@ TEST_CASE("Connection obstruction", "[obstruction-layout]")
         CHECK(!obstr_lyt.is_obstructed_connection({3, 3}, {2, 2}));
         CHECK(!obstr_lyt.is_obstructed_connection({3, 3}, {2, 3}));
 
+        // remove some artificial obstructions
+        obstr_lyt.clear_obstructed_connection({0, 0}, {0, 1});
+
+        CHECK(!obstr_lyt.is_obstructed_connection({0, 0}, {0, 1}));
+        CHECK(obstr_lyt.is_obstructed_connection({2, 2}, {2, 3}));
+        CHECK(obstr_lyt.is_obstructed_connection({2, 4}, {4, 0}));
+
+        // removing an obstruction that was not added manually should not change anything
+        obstr_lyt.clear_obstructed_connection({1, 1}, {2, 1});
+        obstr_lyt.clear_obstructed_connection({2, 0}, {2, 1});
+        obstr_lyt.clear_obstructed_connection({3, 1}, {2, 1});
+
+        CHECK(obstr_lyt.is_obstructed_connection({1, 1}, {2, 1}));
+        CHECK(obstr_lyt.is_obstructed_connection({2, 0}, {2, 1}));
+        CHECK(obstr_lyt.is_obstructed_connection({3, 1}, {2, 1}));
+
+        // remove all artificial obstructions
         obstr_lyt.clear_obstructed_connections();
 
         CHECK(!obstr_lyt.is_obstructed_connection({0, 0}, {0, 1}));
@@ -379,6 +463,14 @@ TEST_CASE("Connection obstruction", "[obstruction-layout]")
         CHECK(!obstr_lyt.is_obstructed_connection({3, 3}, {2, 2}));
         CHECK(!obstr_lyt.is_obstructed_connection({3, 3}, {2, 3}));
 
+        // remove some artificial obstructions
+        obstr_lyt.clear_obstructed_connection({0, 0}, {0, 1});
+
+        CHECK(!obstr_lyt.is_obstructed_connection({0, 0}, {0, 1}));
+        CHECK(obstr_lyt.is_obstructed_connection({2, 2}, {2, 3}));
+        CHECK(obstr_lyt.is_obstructed_connection({2, 4}, {4, 0}));
+
+        // remove all artificial obstructions
         obstr_lyt.clear_obstructed_connections();
 
         CHECK(!obstr_lyt.is_obstructed_connection({0, 0}, {0, 1}));


### PR DESCRIPTION
## Description

When an `obstruction_layout` with manually declared obstructions is fed into `yen_k_shortest_paths`, these obstructions are invalidated during the algorithm's run. This PR fixes the issue.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
