### PR TITLE
:building_construction: Include `alice` only if the CLI is to be built

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Include alice
-set(ALICE_EXAMPLES OFF CACHE BOOL "" FORCE)
-set(ALICE_TEST OFF CACHE BOOL "" FORCE)
-add_subdirectory(alice/)
+if (FICTION_CLI)
+    set(ALICE_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(ALICE_TEST OFF CACHE BOOL "" FORCE)
+    add_subdirectory(alice/)
+endif ()
 
 # Include mockturtle
 set(MOCKTURTLE_EXAMPLES OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
## Description

Due to some older `pybind11` version that is shipped with `alice`, it can lead to issues including *fiction* as a submodule. This PR allows users to circumvent the inclusion of `alice` by disabling *fiction*'s CLI.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
