### PR TITLE
:zap: Utilize `std::string_view` instead of `std::string` in many places to improve performance

### DIFF
--- a/experiments/color_routing/color_routing.cpp
+++ b/experiments/color_routing/color_routing.cpp
@@ -21,12 +21,13 @@
 #include <cstdint>
 #include <cstdlib>
 #include <string>
+#include <string_view>
 
 using gate_lyt = fiction::gate_level_layout<
     fiction::clocked_layout<fiction::tile_based_layout<fiction::cartesian_layout<fiction::offset::ucoord_t>>>>;
 
 using color_routing_experiment =
-    experiments::experiment<std::string, uint32_t, uint32_t, uint32_t, std::string, uint64_t, uint64_t, uint64_t,
+    experiments::experiment<std::string, uint32_t, uint32_t, uint32_t, std::string_view, uint64_t, uint64_t, uint64_t,
                             uint32_t, uint32_t, uint64_t, uint64_t, uint64_t, uint64_t, double, double, double, double,
                             bool>;
 

--- a/include/fiction/io/csv_writer.hpp
+++ b/include/fiction/io/csv_writer.hpp
@@ -6,7 +6,7 @@
 #define FICTION_CSV_WRITER_HPP
 
 #include <fstream>
-#include <string>
+#include <string_view>
 
 namespace fiction
 {
@@ -19,7 +19,7 @@ class csv_writer
      *
      * @param filename CSV file to write into.
      */
-    explicit csv_writer(const std::string& filename) : file{filename, std::ios::out | std::ios::app} {}
+    explicit csv_writer(const std::string_view& filename) : file{filename.data(), std::ios::out | std::ios::app} {}
     /**
      * Writes a single line of comma-separated values to the stored file. Note that no escape checks are performed.
      *

--- a/include/fiction/io/dot_drawers.hpp
+++ b/include/fiction/io/dot_drawers.hpp
@@ -19,6 +19,8 @@
 #include <algorithm>
 #include <array>
 #include <string>
+#include <string_view>
+#include <vector>
 
 namespace fiction
 {
@@ -173,7 +175,7 @@ class technology_dot_drawer : public mockturtle::gate_dot_drawer<Ntk>
         return label;
     }
 
-    [[nodiscard]] bool is_node_number(const std::string& s) const noexcept
+    [[nodiscard]] bool is_node_number(const std::string_view& s) const noexcept
     {
         return !s.empty() && std::all_of(s.begin(), s.end(), ::isdigit);
     }
@@ -372,14 +374,18 @@ class simple_gate_layout_tile_drawer : public technology_dot_drawer<Lyt, DrawInd
     [[nodiscard]] std::vector<std::vector<std::string>> rows(const Lyt& lyt) const noexcept
     {
         std::vector<std::vector<std::string>> rows{};
+        rows.reserve(lyt.y() + 1);
 
         for (auto y = 0ul; y <= lyt.y(); ++y)
         {
             std::vector<std::string> row{};
+            row.reserve(lyt.x() + 1);
+
             for (auto x = 0ul; x <= lyt.x(); ++x)
             {
                 row.emplace_back(tile_id({x, y}));
             }
+
             rows.push_back(row);
         }
 
@@ -389,14 +395,18 @@ class simple_gate_layout_tile_drawer : public technology_dot_drawer<Lyt, DrawInd
     [[nodiscard]] std::vector<std::vector<std::string>> columns(const Lyt& lyt) const noexcept
     {
         std::vector<std::vector<std::string>> columns{};
+        columns.reserve(lyt.x() + 1);
 
         for (auto x = 0ul; x <= lyt.x(); ++x)
         {
             std::vector<std::string> col{};
+            col.reserve(lyt.y() + 1);
+
             for (auto y = 0ul; y <= lyt.y(); ++y)
             {
                 col.emplace_back(tile_id({x, y}));
             }
+
             columns.push_back(col);
         }
 
@@ -408,7 +418,7 @@ class simple_gate_layout_tile_drawer : public technology_dot_drawer<Lyt, DrawInd
         return fmt::format("rank = same {{ {} }};\n", fmt::join(rank, " -> "));
     }
 
-    [[nodiscard]] std::string edge(const std::string& src, const std::string& tgt) const noexcept
+    [[nodiscard]] std::string edge(const std::string_view& src, const std::string_view& tgt) const noexcept
     {
         return fmt::format("{} -> {};\n", src, tgt);
     }
@@ -972,9 +982,9 @@ void write_dot_layout(const Lyt& lyt, std::ostream& os, const Drawer& drawer = {
  * \param filename Filename
  */
 template <class Lyt, class Drawer>
-void write_dot_layout(const Lyt& lyt, const std::string& filename, const Drawer& drawer = {})
+void write_dot_layout(const Lyt& lyt, const std::string_view& filename, const Drawer& drawer = {})
 {
-    std::ofstream os{filename.c_str(), std::ofstream::out};
+    std::ofstream os{filename.data(), std::ofstream::out};
     write_dot_layout(lyt, os, drawer);
     os.close();
 }

--- a/include/fiction/io/network_reader.hpp
+++ b/include/fiction/io/network_reader.hpp
@@ -21,6 +21,7 @@
 #include <filesystem>
 #include <ostream>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 
@@ -41,7 +42,7 @@ class network_reader
      * @param filename Path to the file or folder of files to read.
      * @param out Output stream to write status updates into.
      */
-    network_reader(const std::string& filename, std::ostream& o) : out{o}
+    network_reader(const std::string_view& filename, std::ostream& o) : out{o}
     {
         constexpr const char* verilog_ext = ".v";
         constexpr const char* aig_ext     = ".aig";
@@ -56,7 +57,7 @@ class network_reader
                                [&p](const auto& valid) { return std::filesystem::path(p).extension() == valid; });
         };
 
-        std::vector<std::string> paths{};
+        std::vector<std::string_view> paths{};
 
         // check for given file's properties
         if (std::filesystem::exists(filename))
@@ -176,14 +177,15 @@ class network_reader
      * @param rfun The actual parsing function.
      */
     template <class Reader, class ReadFun>
-    void read(const std::string& file, ReadFun rfun) noexcept
+    void read(const std::string_view& file, ReadFun rfun) noexcept
     {
         Ntk ntk{};
 
         try
         {
             lorina::text_diagnostics client{};
-            if (lorina::diagnostic_engine diag{&client}; rfun(file, Reader{ntk}, &diag) == lorina::return_code::success)
+            if (lorina::diagnostic_engine diag{&client};
+                rfun(file.data(), Reader{ntk}, &diag) == lorina::return_code::success)
             {
                 const auto name = std::filesystem::path{file}.stem().string();
 

--- a/include/fiction/io/read_fqca_layout.hpp
+++ b/include/fiction/io/read_fqca_layout.hpp
@@ -15,6 +15,7 @@
 #include <regex>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 namespace fiction
@@ -93,7 +94,7 @@ template <typename Lyt>
 class read_fqca_layout_impl
 {
   public:
-    explicit read_fqca_layout_impl(std::istream& s, const std::string& name) : lyt{{}, name}, is{s} {}
+    explicit read_fqca_layout_impl(std::istream& s, const std::string_view& name) : lyt{{}, name.data()}, is{s} {}
 
     Lyt run()
     {
@@ -337,7 +338,7 @@ class read_fqca_layout_impl
  * @param name The name to give to the generated layout.
  */
 template <typename Lyt>
-Lyt read_fqca_layout(std::istream& is, const std::string& name = "")
+Lyt read_fqca_layout(std::istream& is, const std::string_view& name = "")
 {
     static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
     static_assert(has_qca_technology_v<Lyt>, "Lyt must be a QCA layout");
@@ -360,9 +361,9 @@ Lyt read_fqca_layout(std::istream& is, const std::string& name = "")
  * @param name The name to give to the generated layout.
  */
 template <typename Lyt>
-Lyt read_fqca_layout(const std::string& filename, const std::string& name = "")
+Lyt read_fqca_layout(const std::string_view& filename, const std::string_view& name = "")
 {
-    std::ifstream is{filename.c_str(), std::ifstream::in};
+    std::ifstream is{filename.data(), std::ifstream::in};
 
     if (!is.is_open())
     {

--- a/include/fiction/io/read_sidb_surface_defects.hpp
+++ b/include/fiction/io/read_sidb_surface_defects.hpp
@@ -17,6 +17,7 @@
 #include <istream>
 #include <regex>
 #include <string>
+#include <string_view>
 
 namespace fiction
 {
@@ -85,8 +86,8 @@ template <typename Lyt>
 class read_sidb_surface_defects_impl
 {
   public:
-    explicit read_sidb_surface_defects_impl(std::istream& s, const std::string& name) :
-            lyt{sidb_surface{Lyt{{}, name}}},
+    explicit read_sidb_surface_defects_impl(std::istream& s, const std::string_view& name) :
+            lyt{sidb_surface{Lyt{{}, name.data()}}},
             defect_matrix{std::istreambuf_iterator<char>(s), {}}  // read the stream into a string to perform regex
     {}
 
@@ -173,7 +174,7 @@ class read_sidb_surface_defects_impl
  * @param name The name to give to the generated layout.
  */
 template <typename Lyt>
-sidb_surface<Lyt> read_sidb_surface_defects(std::istream& is, const std::string& name = "")
+sidb_surface<Lyt> read_sidb_surface_defects(std::istream& is, const std::string_view& name = "")
 {
     static_assert(is_cell_level_layout_v<Lyt>, "Lyt is not a cell-level layout");
     static_assert(has_sidb_technology_v<Lyt>, "Lyt must be an SiDB layout");
@@ -198,9 +199,9 @@ sidb_surface<Lyt> read_sidb_surface_defects(std::istream& is, const std::string&
  * @param name The name to give to the generated layout.
  */
 template <typename Lyt>
-sidb_surface<Lyt> read_sidb_surface_defects(const std::string& filename, const std::string& name = "")
+sidb_surface<Lyt> read_sidb_surface_defects(const std::string_view& filename, const std::string_view& name = "")
 {
-    std::ifstream is{filename.c_str(), std::ifstream::in};
+    std::ifstream is{filename.data(), std::ifstream::in};
 
     if (!is.is_open())
     {

--- a/include/fiction/io/write_qcc_layout.hpp
+++ b/include/fiction/io/write_qcc_layout.hpp
@@ -22,6 +22,7 @@
 #include <ostream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -42,7 +43,7 @@ struct write_qcc_layout_params
     /**
      * Filename of the QCC file.
      */
-    std::string filename{};
+    std::string_view filename{};
 };
 
 namespace detail
@@ -373,9 +374,9 @@ void write_qcc_layout(const Lyt& lyt, std::ostream& os, write_qcc_layout_params 
  * @param ps Parameters.
  */
 template <typename Lyt>
-void write_qcc_layout(const Lyt& lyt, const std::string& filename, write_qcc_layout_params ps = {})
+void write_qcc_layout(const Lyt& lyt, const std::string_view& filename, write_qcc_layout_params ps = {})
 {
-    std::ofstream os{filename.c_str(), std::ofstream::out};
+    std::ofstream os{filename.data(), std::ofstream::out};
 
     if (!os.is_open())
     {

--- a/include/fiction/layouts/cell_level_layout.hpp
+++ b/include/fiction/layouts/cell_level_layout.hpp
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <utility>
 
 namespace fiction
@@ -57,8 +58,8 @@ class cell_level_layout : public ClockedLayout
     template <typename Cell>
     struct cell_level_layout_storage
     {
-        explicit cell_level_layout_storage(std::string name, uint16_t tile_x = 1u, uint16_t tile_y = 1u) :
-                layout_name{std::move(name)},
+        explicit cell_level_layout_storage(const std::string_view& name, uint16_t tile_x = 1u, uint16_t tile_y = 1u) :
+                layout_name{name},
                 tile_size_x{tile_x},
                 tile_size_y{tile_y}
         {}
@@ -264,7 +265,7 @@ class cell_level_layout : public ClockedLayout
      */
     [[nodiscard]] std::string get_layout_name() const noexcept
     {
-        return strg->layout_name;
+        return strg->layout_name.data();
     }
     /**
      * Returns the number of non-empty cell types that were assigned to the layout.

--- a/include/fiction/layouts/clocking_scheme.hpp
+++ b/include/fiction/layouts/clocking_scheme.hpp
@@ -16,6 +16,7 @@
 #include <functional>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 
@@ -54,7 +55,7 @@ class clocking_scheme
      * @param cn Number of clock phases that make up one clock cycle, i.e., the number of different clock numbers.
      * @param r Flag to identify the scheme as regular.
      */
-    explicit clocking_scheme(std::string n, clock_function f, const degree in_deg, const degree out_deg,
+    explicit clocking_scheme(std::string_view n, clock_function f, const degree in_deg, const degree out_deg,
                              const clock_number cn = 4, const bool r = true) noexcept :
             name{std::move(n)},
             max_in_degree{in_deg},
@@ -120,7 +121,7 @@ class clocking_scheme
     /**
      * Name of the clocking scheme.
      */
-    const std::string name;
+    const std::string_view name;
     /**
      * Maximum number of inputs the clocking scheme supports per clock zone.
      */
@@ -715,7 +716,7 @@ bool is_linear_scheme(const clocking_scheme<clock_zone<Lyt>>& scheme) noexcept
  * `name` exists.
  */
 template <typename Lyt>
-std::optional<clocking_scheme<clock_zone<Lyt>>> get_clocking_scheme(const std::string& name) noexcept
+std::optional<clocking_scheme<clock_zone<Lyt>>> get_clocking_scheme(const std::string_view& name) noexcept
 {
     static const phmap::flat_hash_map<std::string, clocking_scheme<clock_zone<Lyt>>> scheme_lookup{
         {clock_name::OPEN, open_clocking<Lyt>(num_clks::FOUR)},
@@ -739,7 +740,7 @@ std::optional<clocking_scheme<clock_zone<Lyt>>> get_clocking_scheme(const std::s
         {clock_name::CFE, cfe_clocking<Lyt>()},
         {clock_name::BANCS, bancs_clocking<Lyt>()}};
 
-    auto upper_name = name;
+    std::string upper_name = name.data();
     std::transform(upper_name.begin(), upper_name.end(), upper_name.begin(), ::toupper);
 
     if (const auto it = scheme_lookup.find(upper_name); it != scheme_lookup.cend())


### PR DESCRIPTION
## Description

This PR improves the performance of many string-based functions by switching to `std::string_view` and thus avoiding string copy costs.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
