### PR TITLE
:rotating_light: Fixes for linker errors and CMake name collisions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,29 +14,29 @@ set(CMAKE_CXX_STANDARD ${FICTION_CXX_STANDARD})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Interface library to set project options
-add_library(project_options INTERFACE)
+add_library(fiction_project_options INTERFACE)
 
 # Option to enable time tracing with clang
 if (CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
     option(ENABLE_BUILD_WITH_TIME_TRACE "Enable -ftime-trace to generate time tracing .json files on clang" OFF)
     if (ENABLE_BUILD_WITH_TIME_TRACE)
-        target_compile_options(project_options INTERFACE -ftime-trace)
+        target_compile_options(fiction_project_options INTERFACE -ftime-trace)
     endif ()
 endif ()
 
 # Use the warnings specified in CompilerWarnings.cmake
-add_library(project_warnings INTERFACE)
+add_library(fiction_project_warnings INTERFACE)
 
 # Enable cache system
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Cache.cmake)
 
 # Standard compiler warnings
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CompilerWarnings.cmake)
-set_project_warnings(project_warnings)
+set_project_warnings(fiction_project_warnings)
 
 # Sanitizer options if supported by compiler
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Sanitizers.cmake)
-enable_sanitizers(project_options)
+enable_sanitizers(fiction_project_options)
 
 # Allow for static analysis options
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/StaticAnalyzers.cmake)
@@ -45,7 +45,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/StaticAnalyzers.cmake)
 if (NOT WIN32)
     option(FICTION_PROGRESS_BARS "Enable animated progress bars in command line" ON)
     if (FICTION_PROGRESS_BARS)
-        target_compile_definitions(project_options INTERFACE PROGRESS_BARS)
+        target_compile_definitions(fiction_project_options INTERFACE PROGRESS_BARS)
     endif ()
 endif ()
 

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -7,4 +7,4 @@ include_directories(${PROJECT_BINARY_DIR}/include/)
 add_executable(fiction ${SOURCES})
 
 # Link against the project settings, libfiction, alice, and mockturtle
-target_link_libraries(fiction PRIVATE project_options project_warnings libfiction alice)
+target_link_libraries(fiction PRIVATE fiction_project_options fiction_project_warnings libfiction alice)

--- a/experiments/CMakeLists.txt
+++ b/experiments/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_library(fiction_experiments INTERFACE)
 target_include_directories(fiction_experiments INTERFACE ${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/libs/mockturtle/experiments/)
-target_link_libraries(fiction_experiments INTERFACE fiction_project_options fiction_project_warnings libfiction)
+target_link_libraries(fiction_experiments INTERFACE libfiction)
 if (ENABLE_MATPLOTLIB)
     target_link_libraries(fiction_experiments INTERFACE matplot)
 endif ()

--- a/experiments/CMakeLists.txt
+++ b/experiments/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_library(fiction_experiments INTERFACE)
 target_include_directories(fiction_experiments INTERFACE ${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/libs/mockturtle/experiments/)
-target_link_libraries(fiction_experiments INTERFACE libfiction)
+target_link_libraries(fiction_experiments INTERFACE fiction_project_options fiction_project_warnings libfiction)
 if (ENABLE_MATPLOTLIB)
     target_link_libraries(fiction_experiments INTERFACE matplot)
 endif ()

--- a/include/fiction/technology/sidb_charge_state.hpp
+++ b/include/fiction/technology/sidb_charge_state.hpp
@@ -29,7 +29,7 @@ enum class sidb_charge_state
  * @param cs SiDB charge state.
  * @return Integer representing the SiDB's charge state.
  */
-[[nodiscard]] constexpr int8_t charge_state_to_sign(const sidb_charge_state& cs) noexcept
+[[nodiscard]] inline constexpr int8_t charge_state_to_sign(const sidb_charge_state& cs) noexcept
 {
     switch (cs)
     {
@@ -53,7 +53,7 @@ enum class sidb_charge_state
  * @param sg Charge state as integer (-1,0,1).
  * @return sidb_charge_state representation of `sg`.
  */
-[[nodiscard]] constexpr sidb_charge_state sign_to_charge_state(const int8_t sg) noexcept
+[[nodiscard]] inline constexpr sidb_charge_state sign_to_charge_state(const int8_t sg) noexcept
 {
     assert(((sg == -1) || (sg == 0) || (sg == 1)) && "Invalid charge state.");
 
@@ -83,7 +83,7 @@ enum class sidb_charge_state
  * @param charge_distribution A vector of SiDBs charge states.
  * @return A string representation of the charge states.
  */
-[[nodiscard]] std::string
+[[nodiscard]] inline std::string
 charge_configuration_to_string(const std::vector<sidb_charge_state>& charge_distribution) noexcept
 {
     std::stringstream config_str{};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,7 @@ foreach (FILE IN LISTS FILENAMES)
     set(TEST_NAME test_${NAME})
     add_executable(${TEST_NAME} ${FILE})
     target_compile_definitions(${TEST_NAME} INTERFACE CATCH_CONFIG_NO_POSIX_SIGNALS) # make catch2 ignore SIGTERMs sent to applications when timeouts are reached
-    target_link_libraries(${TEST_NAME} PRIVATE project_warnings project_options libfiction Catch2::Catch2WithMain)
+    target_link_libraries(${TEST_NAME} PRIVATE fiction_project_warnings fiction_project_options libfiction Catch2::Catch2WithMain)
 
     add_test(NAME ${NAME} COMMAND ${TEST_NAME}) # group tests by file
     #    catch_discover_tests(${TEST_NAME})


### PR DESCRIPTION
## Description

This PR fixes some linker issues that occurred because non-template functions were not `inline`d. Furthermore, name collisions in CMake are minimized when *fiction* is used as a library by renaming `project_options` to `fiction_project_options` and `project_warnings` to `fiction_project_warnings`.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
