### PR TITLE
:bug: Fixed error message from multiple IPO Checks

### DIFF
--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -25,7 +25,9 @@ if (ENABLE_IPO)
             RESULT
             ipo_supported
             OUTPUT
-            ipo_output)
+            ipo_output
+            LANGUAGES
+            CXX)
     # enable inter-procedural optimization if it is supported (Clang's ThinLTO does not work with Ubuntu 20.04's default linker at the moment)
     if ((ipo_supported AND NOT ((${CMAKE_SYSTEM_NAME} MATCHES "Linux") AND (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang"))))
         set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)


### PR DESCRIPTION
 Qmap also has a CheckIPOSupported call, which resulted in an error message

## Description

Using fiction as a header only library in qmap results in an cmake error due to multiple IPO checks.


## Checklist:


- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
