### PR TITLE
Fixed IPO error when using as submodule with MQT QMAP

### DIFF
--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -25,7 +25,9 @@ if (ENABLE_IPO)
             RESULT
             ipo_supported
             OUTPUT
-            ipo_output)
+            ipo_output
+            LANGUAGES
+            CXX)
     # enable inter-procedural optimization if it is supported (Clang's ThinLTO does not work with Ubuntu 20.04's default linker at the moment)
     if ((ipo_supported AND NOT ((${CMAKE_SYSTEM_NAME} MATCHES "Linux") AND (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang"))))
         set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)


### PR DESCRIPTION
## Description

The IPO check of qmap and fiction at the same time resulted in a cmake error.


## Checklist:


- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
