### PR TITLE
:bug: Removed excess template parameter `typename T`

### DIFF
--- a/include/fiction/utils/name_utils.hpp
+++ b/include/fiction/utils/name_utils.hpp
@@ -249,7 +249,7 @@ void restore_signal_names(
  * @param ntk_src Source logic network whose I/O names are to be transferred to `ntk_dest`.
  * @param ntk_dest Target logic network whose I/O names are to be assigned `ntk_src`'s names.
  */
-template <typename NtkSrc, typename NtkDest, typename T>
+template <typename NtkSrc, typename NtkDest>
 void restore_names(const NtkSrc& ntk_src, NtkDest& ntk_dest) noexcept
 {
     restore_network_name(ntk_src, ntk_dest);


### PR DESCRIPTION
## Description

Remove excess template parameter `T` when invoking `restore_names()` without a mapping of signals from `ntk_src` to `ntk_dest`.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
