### PR TITLE
:art: Restructured `sidb_charge_state` and added tests

### DIFF
--- a/include/fiction/technology/sidb_charge_state.hpp
+++ b/include/fiction/technology/sidb_charge_state.hpp
@@ -5,9 +5,9 @@
 #ifndef FICTION_SIDB_CHARGE_STATE_HPP
 #define FICTION_SIDB_CHARGE_STATE_HPP
 
-#include <cassert>
 #include <cstdint>
 #include <sstream>
+#include <string>
 #include <vector>
 
 namespace fiction
@@ -16,12 +16,12 @@ namespace fiction
 /**
  * Charge states of SiDBs.
  */
-enum class sidb_charge_state
+enum class sidb_charge_state : int8_t
 {
-    NONE,  // assigned when layout cell is empty
-    POSITIVE,
-    NEUTRAL,
-    NEGATIVE
+    NEGATIVE = -1,
+    NEUTRAL  = 0,
+    POSITIVE = 1,
+    NONE     = 127  // assigned when layout cell is empty
 };
 /**
  * Converts the charge state into an integer (`-1`, `0`, `1`).
@@ -33,13 +33,13 @@ enum class sidb_charge_state
 {
     switch (cs)
     {
-        case sidb_charge_state::POSITIVE:
-        {
-            return +1;
-        }
         case sidb_charge_state::NEGATIVE:
         {
             return -1;
+        }
+        case sidb_charge_state::POSITIVE:
+        {
+            return +1;
         }
         default:
         {
@@ -48,21 +48,15 @@ enum class sidb_charge_state
     }
 }
 /**
- * Converts a charge state (-1,0,1) into an enum.
+ * Converts an integer (`-1`, `0`, `1`) into a charge state.
  *
- * @param sg Charge state as integer (-1,0,1).
+ * @param sg Integer (`-1`, `0`, `1`) representing a charge state.
  * @return sidb_charge_state representation of `sg`.
  */
 [[nodiscard]] inline constexpr sidb_charge_state sign_to_charge_state(const int8_t sg) noexcept
 {
-    assert(((sg == -1) || (sg == 0) || (sg == 1)) && "Invalid charge state.");
-
     switch (sg)
     {
-        case 1:
-        {
-            return sidb_charge_state::POSITIVE;
-        }
         case -1:
         {
             return sidb_charge_state::NEGATIVE;
@@ -70,6 +64,10 @@ enum class sidb_charge_state
         case 0:
         {
             return sidb_charge_state::NEUTRAL;
+        }
+        case +1:
+        {
+            return sidb_charge_state::POSITIVE;
         }
         default:
         {
@@ -99,19 +97,19 @@ charge_configuration_to_string(const std::vector<sidb_charge_state>& charge_dist
         {
             case sidb_charge_state::NEGATIVE:
             {
-                config_str << "-";
+                config_str << '-';
 
                 break;
             }
             case sidb_charge_state::NEUTRAL:
             {
-                config_str << "0";
+                config_str << '0';
 
                 break;
             }
             case sidb_charge_state::POSITIVE:
             {
-                config_str << "+";
+                config_str << '+';
 
                 break;
             }

--- a/test/technology/sidb_charge_state.cpp
+++ b/test/technology/sidb_charge_state.cpp
@@ -1,0 +1,105 @@
+//
+// Created by marcel on 29.03.23.
+//
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <fiction/technology/sidb_charge_state.hpp>
+
+#include <cstdint>
+#include <limits>
+
+using namespace fiction;
+
+TEST_CASE("charge_state_to_sign returns the correct sign for each charge state", "[sidb-charge-state]")
+{
+    CHECK(charge_state_to_sign(sidb_charge_state::POSITIVE) == 1);
+    CHECK(charge_state_to_sign(sidb_charge_state::NEUTRAL) == 0);
+    CHECK(charge_state_to_sign(sidb_charge_state::NEGATIVE) == -1);
+    CHECK(charge_state_to_sign(sidb_charge_state::NONE) == 0);
+}
+
+TEST_CASE("charge_state_to_sign is noexcept", "[sidb-charge-state]")
+{
+    CHECK(noexcept(charge_state_to_sign(sidb_charge_state::NEUTRAL)));
+}
+
+TEST_CASE("sign_to_charge_state returns the correct charge state for each sign", "[sidb-charge-state]")
+{
+    SECTION("sg is -1")
+    {
+        CHECK(sign_to_charge_state(-1) == sidb_charge_state::NEGATIVE);
+    }
+
+    SECTION("sg is 0")
+    {
+        CHECK(sign_to_charge_state(0) == sidb_charge_state::NEUTRAL);
+    }
+
+    SECTION("sg is +1")
+    {
+        CHECK(sign_to_charge_state(1) == sidb_charge_state::POSITIVE);
+    }
+
+    SECTION("sg is invalid")
+    {
+        CHECK(sign_to_charge_state(2) == sidb_charge_state::NONE);
+        CHECK(sign_to_charge_state(3) == sidb_charge_state::NONE);
+        CHECK(sign_to_charge_state(4) == sidb_charge_state::NONE);
+        CHECK(sign_to_charge_state(std::numeric_limits<int8_t>::max()) == sidb_charge_state::NONE);
+
+        CHECK(sign_to_charge_state(-2) == sidb_charge_state::NONE);
+        CHECK(sign_to_charge_state(-3) == sidb_charge_state::NONE);
+        CHECK(sign_to_charge_state(-4) == sidb_charge_state::NONE);
+        CHECK(sign_to_charge_state(std::numeric_limits<int8_t>::min()) == sidb_charge_state::NONE);
+    }
+}
+
+TEST_CASE("sign_to_charge_state is noexcept", "[sidb-charge-state]")
+{
+    CHECK(noexcept(sign_to_charge_state(0)));
+}
+
+TEST_CASE("charge_configuration_to_string builds correct strings", "[sidb-charge-state]")
+{
+    SECTION("empty charge configuration")
+    {
+        const std::vector<sidb_charge_state> charge_distribution{};
+
+        CHECK(charge_configuration_to_string(charge_distribution).empty());
+    }
+
+    SECTION("charge configuration with one negative charge")
+    {
+        const std::vector<sidb_charge_state> charge_distribution{sidb_charge_state::NEGATIVE};
+
+        CHECK(charge_configuration_to_string(charge_distribution) == "-");
+    }
+
+    SECTION("charge configuration with one neutral charge")
+    {
+        const std::vector<sidb_charge_state> charge_distribution{sidb_charge_state::NEUTRAL};
+
+        CHECK(charge_configuration_to_string(charge_distribution) == "0");
+    }
+
+    SECTION("charge configuration with one positive charge")
+    {
+        const std::vector<sidb_charge_state> charge_distribution{sidb_charge_state::POSITIVE};
+
+        CHECK(charge_configuration_to_string(charge_distribution) == "+");
+    }
+
+    SECTION("charge configuration with multiple charges")
+    {
+        const std::vector<sidb_charge_state> charge_distribution{
+            sidb_charge_state::POSITIVE, sidb_charge_state::NEGATIVE, sidb_charge_state::NEUTRAL};
+
+        CHECK(charge_configuration_to_string(charge_distribution) == "+-0");
+    }
+}
+
+TEST_CASE("charge_configuration_to_string is noexcept", "[sidb-charge-state]")
+{
+    CHECK(noexcept(charge_configuration_to_string({})));
+}


### PR DESCRIPTION
## Description

This PR adds tests for the functions associated with `sidb_charge_state` and restructures the respective header a bit.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
