### PR TITLE
:sparkles: Make ClangFormat aware of different line ending types and enforce `LF`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -84,5 +84,6 @@ SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard: c++17
 UseTab: Never
+LineEnding: LF
 
 ...

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -31,12 +31,11 @@ jobs:
           submodules: recursive
 
       - name: Run ClangFormat
-        uses: DoozyX/clang-format-lint-action@v0.16
+        uses: DoozyX/clang-format-lint-action@v0.16.1
         with:
           source: 'include test experiments'
-          exclude: '*/catch2/*.hpp'
           extensions: 'hpp,cpp'
-          clangFormatVersion: 15
+          clangFormatVersion: 16
           inplace: True
 
       - uses: EndBug/add-and-commit@v9

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -32,7 +32,7 @@ jobs:
             -DMOCKTURTLE_EXAMPLES=OFF
           build_dir: build
           config_file: '.clang-tidy'
-          exclude: 'libs/*, docs/*, benchmarks/*, bib/*, */catch2/*.hpp'
+          exclude: 'libs/*, docs/*, benchmarks/*, bib/*'
           split_workflow: true
 
       - name: Make sure that the review file exists

--- a/experiments/bestagon/bestagon.cpp
+++ b/experiments/bestagon/bestagon.cpp
@@ -9,14 +9,14 @@
 #include <fiction/algorithms/physical_design/apply_gate_library.hpp>  // layout conversion to cell-level
 #include <fiction/algorithms/physical_design/exact.hpp>               // SMT-based physical design of FCN layouts
 #include <fiction/algorithms/properties/critical_path_length_and_throughput.hpp>  // critical path and throughput calculations
-#include <fiction/io/write_sqd_layout.hpp>                    // writer for SiQAD files (physical simulation)
-#include <fiction/networks/technology_network.hpp>            // technology-mapped network type
-#include <fiction/technology/area.hpp>                        // area requirement calculations
-#include <fiction/technology/cell_technologies.hpp>           // cell implementations
-#include <fiction/technology/sidb_bestagon_library.hpp>       // a pre-defined SiDB gate library
-#include <fiction/technology/technology_mapping_library.hpp>  // pre-defined gate types for technology mapping
-#include <fiction/traits.hpp>                                 // traits for type-checking
-#include <fiction/types.hpp>                                  // pre-defined types suitable for the FCN domain
+#include <fiction/io/write_sqd_layout.hpp>                     // writer for SiQAD files (physical simulation)
+#include <fiction/networks/technology_network.hpp>             // technology-mapped network type
+#include <fiction/technology/area.hpp>                         // area requirement calculations
+#include <fiction/technology/cell_technologies.hpp>            // cell implementations
+#include <fiction/technology/sidb_bestagon_library.hpp>        // a pre-defined SiDB gate library
+#include <fiction/technology/technology_mapping_library.hpp>   // pre-defined gate types for technology mapping
+#include <fiction/traits.hpp>                                  // traits for type-checking
+#include <fiction/types.hpp>                                   // pre-defined types suitable for the FCN domain
 
 #include <fmt/format.h>                                        // output formatting
 #include <lorina/genlib.hpp>                                   // Genlib file parsing

--- a/experiments/color_routing/color_routing.cpp
+++ b/experiments/color_routing/color_routing.cpp
@@ -13,10 +13,10 @@
 #include <fiction/types.hpp>                                         // pre-defined types suitable for the FCN domain
 #include <fiction/utils/routing_utils.hpp>                           // routing utility functions
 
-#include <fmt/format.h>                      // output formatting
-#include <lorina/lorina.hpp>                 // Verilog/BLIF/AIGER/... file parsing
-#include <mockturtle/io/verilog_reader.hpp>  // call-backs to read Verilog files into networks
-#include <mockturtle/networks/aig.hpp>       // AND-inverter graphs
+#include <fmt/format.h>                                              // output formatting
+#include <lorina/lorina.hpp>                                         // Verilog/BLIF/AIGER/... file parsing
+#include <mockturtle/io/verilog_reader.hpp>                          // call-backs to read Verilog files into networks
+#include <mockturtle/networks/aig.hpp>                               // AND-inverter graphs
 
 #include <cstdint>
 #include <cstdlib>

--- a/experiments/defect_aware_physical_design/defect_aware_physical_design.cpp
+++ b/experiments/defect_aware_physical_design/defect_aware_physical_design.cpp
@@ -10,16 +10,16 @@
 #include <fiction/algorithms/physical_design/exact.hpp>               // SMT-based physical design of FCN layouts
 #include <fiction/algorithms/properties/critical_path_length_and_throughput.hpp>  // critical path and throughput calculations
 #include <fiction/io/read_sidb_surface_defects.hpp>                               // reader for simulated SiDB surfaces
-#include <fiction/io/read_sqd_layout.hpp>                     // reader for SiDB layouts including surface scan data
-#include <fiction/io/write_sqd_layout.hpp>                    // writer for SiQAD files (physical simulation)
-#include <fiction/technology/area.hpp>                        // area requirement calculations
-#include <fiction/technology/cell_technologies.hpp>           // cell implementations
-#include <fiction/technology/sidb_bestagon_library.hpp>       // a pre-defined SiDB gate library
-#include <fiction/technology/sidb_defects.hpp>                // SiDB defect classes
-#include <fiction/technology/sidb_surface.hpp>                // H-Si(100) 2x1 surface model
-#include <fiction/technology/sidb_surface_analysis.hpp>       // SiDB surface analysis
-#include <fiction/technology/technology_mapping_library.hpp>  // pre-defined gate types for technology mapping
-#include <fiction/types.hpp>                                  // pre-defined types suitable for the FCN domain
+#include <fiction/io/read_sqd_layout.hpp>                      // reader for SiDB layouts including surface scan data
+#include <fiction/io/write_sqd_layout.hpp>                     // writer for SiQAD files (physical simulation)
+#include <fiction/technology/area.hpp>                         // area requirement calculations
+#include <fiction/technology/cell_technologies.hpp>            // cell implementations
+#include <fiction/technology/sidb_bestagon_library.hpp>        // a pre-defined SiDB gate library
+#include <fiction/technology/sidb_defects.hpp>                 // SiDB defect classes
+#include <fiction/technology/sidb_surface.hpp>                 // H-Si(100) 2x1 surface model
+#include <fiction/technology/sidb_surface_analysis.hpp>        // SiDB surface analysis
+#include <fiction/technology/technology_mapping_library.hpp>   // pre-defined gate types for technology mapping
+#include <fiction/types.hpp>                                   // pre-defined types suitable for the FCN domain
 
 #include <fmt/format.h>                                        // output formatting
 #include <lorina/genlib.hpp>                                   // Genlib file parsing

--- a/experiments/defect_aware_physical_design/generate_defective_surface.py
+++ b/experiments/defect_aware_physical_design/generate_defective_surface.py
@@ -1,10 +1,11 @@
 # this one treats each H-Si as an array value
 
 
-import matplotlib.pyplot as plt
-import numpy as np
 import random
 import sys
+
+import matplotlib.pyplot as plt
+import numpy as np
 
 np.set_printoptions(threshold=sys.maxsize)
 from matplotlib.axes._axes import _log as matplotlib_axes_logger

--- a/experiments/libfiction_demo.cpp
+++ b/experiments/libfiction_demo.cpp
@@ -9,19 +9,19 @@
 #include <fiction/algorithms/physical_design/exact.hpp>               // SMT-based physical design of FCN layouts
 #include <fiction/algorithms/physical_design/orthogonal.hpp>          // scalable physical design of FCN layouts
 #include <fiction/io/dot_drawers.hpp>                                 // DOT drawers for logic networks and layouts
-#include <fiction/io/write_qca_layout.hpp>           // writer for QCADesigner files (physical simulation)
-#include <fiction/io/write_sqd_layout.hpp>           // writer for SiQAD files (physical simulation)
-#include <fiction/io/write_svg_layout.hpp>           // SVG writer for cell-level layout representation
-#include <fiction/layouts/cartesian_layout.hpp>      // Cartesian grid layouts
-#include <fiction/layouts/cell_level_layout.hpp>     // cell-level abstraction of layouts
-#include <fiction/layouts/coordinates.hpp>           // coordinate systems
-#include <fiction/layouts/gate_level_layout.hpp>     // gate-level abstraction of layouts
-#include <fiction/layouts/tile_based_layout.hpp>     // tile-based abstraction of layouts
-#include <fiction/technology/area.hpp>               // area requirement calculations
-#include <fiction/technology/cell_technologies.hpp>  // pre-defined cell implementations
-#include <fiction/technology/qca_one_library.hpp>    // a pre-defined QCA gate library
-#include <fiction/types.hpp>                         // pre-defined types suitable for the FCN domain
-#include <fiction/utils/debug/network_writer.hpp>    // DOT writer for logic networks and layouts
+#include <fiction/io/write_qca_layout.hpp>                     // writer for QCADesigner files (physical simulation)
+#include <fiction/io/write_sqd_layout.hpp>                     // writer for SiQAD files (physical simulation)
+#include <fiction/io/write_svg_layout.hpp>                     // SVG writer for cell-level layout representation
+#include <fiction/layouts/cartesian_layout.hpp>                // Cartesian grid layouts
+#include <fiction/layouts/cell_level_layout.hpp>               // cell-level abstraction of layouts
+#include <fiction/layouts/coordinates.hpp>                     // coordinate systems
+#include <fiction/layouts/gate_level_layout.hpp>               // gate-level abstraction of layouts
+#include <fiction/layouts/tile_based_layout.hpp>               // tile-based abstraction of layouts
+#include <fiction/technology/area.hpp>                         // area requirement calculations
+#include <fiction/technology/cell_technologies.hpp>            // pre-defined cell implementations
+#include <fiction/technology/qca_one_library.hpp>              // a pre-defined QCA gate library
+#include <fiction/types.hpp>                                   // pre-defined types suitable for the FCN domain
+#include <fiction/utils/debug/network_writer.hpp>              // DOT writer for logic networks and layouts
 
 #include <fmt/format.h>                                        // output formatting
 #include <lorina/lorina.hpp>                                   // Verilog/BLIF/AIGER/... file parsing
@@ -33,10 +33,10 @@
 #include <mockturtle/views/depth_view.hpp>                     // to determine network levels
 #include <mockturtle/views/names_view.hpp>                     // to assign names to network signals
 
-#include <cstdlib>     // exit codes
-#include <filesystem>  // filesystem access
-#include <iostream>    // output
-#include <string>      // strings
+#include <cstdlib>                                             // exit codes
+#include <filesystem>                                          // filesystem access
+#include <iostream>                                            // output
+#include <string>                                              // strings
 
 template <typename Ntk>
 void print_network_properties(const Ntk& ntk)

--- a/include/fiction/algorithms/path_finding/a_star.hpp
+++ b/include/fiction/algorithms/path_finding/a_star.hpp
@@ -78,7 +78,7 @@ class a_star_impl
 
         } while (!open_list.empty());  // until the open list is empty
 
-        return {};  // open list is empty, no path has been found
+        return {};                     // open list is empty, no path has been found
     }
 
   private:

--- a/include/fiction/algorithms/path_finding/jump_point_search.hpp
+++ b/include/fiction/algorithms/path_finding/jump_point_search.hpp
@@ -65,7 +65,7 @@ class jump_point_search_impl
 
         } while (!open_list.empty());  // until the open list is empty
 
-        return {};  // open list is empty, no path has been found
+        return {};                     // open list is empty, no path has been found
     }
 
   private:

--- a/include/fiction/algorithms/physical_design/one_pass_synthesis.hpp
+++ b/include/fiction/algorithms/physical_design/one_pass_synthesis.hpp
@@ -38,7 +38,7 @@
 #pragma GCC diagnostic ignored "-Wuseless-cast"
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma GCC diagnostic ignored "-Wrange-loop-analysis"
-#pragma warning(push, 0)  // MSVC
+#pragma warning(push, 0)    // MSVC
 #include <pybind11/embed.h>
 #pragma GCC diagnostic pop  // GCC
 #pragma warning(pop)        // MSVC
@@ -166,7 +166,7 @@ class mugen_handler
             tts{spec},
             num_pis{spec[0].num_vars()},  // since all tts have to have the same number of variables
             lyt{sketch},
-            ps{std::move(p)},  // need a copy because timeout will be altered
+            ps{std::move(p)},             // need a copy because timeout will be altered
             pi_list(num_pis),
             mugen{pybind11::module::import("mugen")}
     {}

--- a/include/fiction/io/read_fqca_layout.hpp
+++ b/include/fiction/io/read_fqca_layout.hpp
@@ -74,10 +74,10 @@ namespace qca_stack
 static const std::regex RE_WHITE_SPACE{R"(\s)"};
 static const std::regex RE_COMMENT{R"(\[.*\]$)"};
 static const std::regex RE_LAYER_SEPARATOR{R"(^=+$)"};
-static const std::regex RE_CELL_DEFINITION_ID{R"(^(\w)\:$)"};              // group 1 is the id
-static const std::regex RE_CELL_DEFINITION_LABEL{R"(^-label=\"(.*)\"$)"};  // group 1 is the label
-static const std::regex RE_CELL_DEFINITION_CLOCK{R"(^-clock=(\d)$)"};      // group 1 is the clock number
-static const std::regex RE_CELL_DEFINITION_NUMBER{R"(^-number=(\d+)$)"};   // group 1 is the number
+static const std::regex RE_CELL_DEFINITION_ID{R"(^(\w)\:$)"};                   // group 1 is the id
+static const std::regex RE_CELL_DEFINITION_LABEL{R"(^-label=\"(.*)\"$)"};       // group 1 is the label
+static const std::regex RE_CELL_DEFINITION_CLOCK{R"(^-clock=(\d)$)"};           // group 1 is the clock number
+static const std::regex RE_CELL_DEFINITION_NUMBER{R"(^-number=(\d+)$)"};        // group 1 is the number
 static const std::regex RE_CELL_DEFINITION_OFFSET{
     R"(^-offset=\((-?\d*(?:\.\d+)?),(-?\d*(?:\.\d+)?),(-?\d*(?:\.\d+)?)\)$)"};  // group 1, 2, and 3 are the x, y, and z
                                                                                 // offset respectively

--- a/include/fiction/io/write_qcc_layout.hpp
+++ b/include/fiction/io/write_qcc_layout.hpp
@@ -177,7 +177,7 @@ class write_qcc_layout_impl
                     all_border_pins = false;
                     return false;  // break iteration
                 }
-                return true;  // keep iterating
+                return true;       // keep iterating
             });
         // check PO border cells
         lyt.foreach_po(
@@ -188,7 +188,7 @@ class write_qcc_layout_impl
                     all_border_pins = false;
                     return false;  // break iteration
                 }
-                return true;  // keep iterating
+                return true;       // keep iterating
             });
 
         return all_border_pins;

--- a/include/fiction/io/write_qll_layout.hpp
+++ b/include/fiction/io/write_qll_layout.hpp
@@ -187,7 +187,7 @@ class write_qll_layout_impl
                     all_border_pins = false;
                     return false;  // break iteration
                 }
-                return true;  // keep iterating
+                return true;       // keep iterating
             });
         // check PO border cells
         lyt.foreach_po(
@@ -198,7 +198,7 @@ class write_qll_layout_impl
                     all_border_pins = false;
                     return false;  // break iteration
                 }
-                return true;  // keep iterating
+                return true;       // keep iterating
             });
 
         return all_border_pins;

--- a/test/algorithms/path_finding/a_star.cpp
+++ b/test/algorithms/path_finding/a_star.cpp
@@ -170,7 +170,7 @@ TEST_CASE("A* on 4x4 gate-level layouts with coordinate obstruction", "[A*]")
             obstruction_layout obstr_lyt{layout};
 
             // create a PI as obstruction
-            obstr_lyt.create_pi("obstruction", {3, 0});  // blocks 3 paths
+            obstr_lyt.create_pi("obstruction", {3, 0});                         // blocks 3 paths
 
             const auto path = a_star<coord_path>(obstr_lyt, {{0, 0}, {3, 3}});  // only one path possible
             const auto dist = a_star_distance(obstr_lyt, {0, 0}, {3, 3});
@@ -208,7 +208,7 @@ TEST_CASE("A* with coordinate obstruction but crossings enabled", "[A*]")
             {
                 const gate_lyt layout{{2, 2, 1}, twoddwave_clocking<gate_lyt>()};  // create a crossing layer
 
-                SECTION("(0,0) to (2,2) with obstruction and crossings")  // 1 valid path
+                SECTION("(0,0) to (2,2) with obstruction and crossings")           // 1 valid path
                 {
                     obstruction_layout obstr_lyt{layout};
 
@@ -226,7 +226,7 @@ TEST_CASE("A* with coordinate obstruction but crossings enabled", "[A*]")
             {
                 const gate_lyt layout{{2, 2, 1}, use_clocking<gate_lyt>()};  // create a crossing layer
 
-                SECTION("(0,0) to (2,2) with obstruction and crossings")  // 1 valid path
+                SECTION("(0,0) to (2,2) with obstruction and crossings")     // 1 valid path
                 {
                     obstruction_layout obstr_lyt{layout};
 
@@ -250,7 +250,7 @@ TEST_CASE("A* with coordinate obstruction but crossings enabled", "[A*]")
             {
                 const gate_lyt layout{{3, 3, 1}, twoddwave_clocking<gate_lyt>()};  // create a crossing layer
 
-                SECTION("(0,0) to (3,3) with obstruction and crossings")  // 2 valid paths
+                SECTION("(0,0) to (3,3) with obstruction and crossings")           // 2 valid paths
                 {
                     obstruction_layout obstr_lyt{layout};
 
@@ -281,7 +281,7 @@ TEST_CASE("A* with coordinate obstruction but crossings enabled", "[A*]")
             {
                 const gate_lyt layout{{3, 2, 1}, twoddwave_clocking<gate_lyt>()};  // create a crossing layer
 
-                SECTION("(0,0) to (3,2) with obstruction and crossings")  // 1 valid paths
+                SECTION("(0,0) to (3,2) with obstruction and crossings")           // 1 valid paths
                 {
                     obstruction_layout obstr_lyt{layout};
 
@@ -343,7 +343,7 @@ TEST_CASE("A* on 4x4 gate-level layouts with connection obstruction", "[A*]")
             obstruction_layout obstr_lyt{layout};
 
             // create a PI as obstruction
-            obstr_lyt.obstruct_connection({2, 0}, {3, 0});  // blocks 3 paths
+            obstr_lyt.obstruct_connection({2, 0}, {3, 0});                      // blocks 3 paths
 
             const auto path = a_star<coord_path>(obstr_lyt, {{0, 0}, {3, 3}});  // only one path possible
 

--- a/test/algorithms/path_finding/enumerate_all_paths.cpp
+++ b/test/algorithms/path_finding/enumerate_all_paths.cpp
@@ -158,7 +158,7 @@ TEST_CASE("Enumerate all paths with coordinate obstruction but crossings enabled
             {
                 const gate_lyt layout{{2, 2, 1}, twoddwave_clocking<gate_lyt>()};  // create a crossing layer
 
-                SECTION("(0,0) to (2,2) with obstruction and crossings")  // 1 valid path
+                SECTION("(0,0) to (2,2) with obstruction and crossings")           // 1 valid path
                 {
                     obstruction_layout obstr_lyt{layout};
 
@@ -177,7 +177,7 @@ TEST_CASE("Enumerate all paths with coordinate obstruction but crossings enabled
             {
                 const gate_lyt layout{{2, 2, 1}, use_clocking<gate_lyt>()};  // create a crossing layer
 
-                SECTION("(0,0) to (2,2) with obstruction and crossings")  // 1 valid path
+                SECTION("(0,0) to (2,2) with obstruction and crossings")     // 1 valid path
                 {
                     obstruction_layout obstr_lyt{layout};
 
@@ -202,7 +202,7 @@ TEST_CASE("Enumerate all paths with coordinate obstruction but crossings enabled
             {
                 const gate_lyt layout{{3, 3, 1}, twoddwave_clocking<gate_lyt>()};  // create a crossing layer
 
-                SECTION("(0,0) to (3,3) with obstruction and crossings")  // 2 valid paths
+                SECTION("(0,0) to (3,3) with obstruction and crossings")           // 2 valid paths
                 {
                     obstruction_layout obstr_lyt{layout};
 
@@ -234,7 +234,7 @@ TEST_CASE("Enumerate all paths with coordinate obstruction but crossings enabled
             {
                 const gate_lyt layout{{3, 2, 1}, twoddwave_clocking<gate_lyt>()};  // create a crossing layer
 
-                SECTION("(0,0) to (3,2) with obstruction and crossings")  // 1 valid paths
+                SECTION("(0,0) to (3,2) with obstruction and crossings")           // 1 valid paths
                 {
                     obstruction_layout obstr_lyt{layout};
 

--- a/test/algorithms/path_finding/jump_point_search.cpp
+++ b/test/algorithms/path_finding/jump_point_search.cpp
@@ -150,7 +150,7 @@ TEST_CASE("JPS on 4x4 gate-level layouts with coordinate obstruction", "[JPS]")
             obstruction_layout obstr_lyt{layout};
 
             // create a PI as obstruction
-            obstr_lyt.create_pi("obstruction", {3, 0});  // blocks 3 paths
+            obstr_lyt.create_pi("obstruction", {3, 0});                                    // blocks 3 paths
 
             const auto path = jump_point_search<coord_path>(obstr_lyt, {{0, 0}, {3, 3}});  // only one path possible
 
@@ -206,7 +206,7 @@ TEST_CASE("JPS on 4x4 gate-level layouts with connection obstruction", "[JPS]")
             obstruction_layout obstr_lyt{layout};
 
             // create a PI as obstruction
-            obstr_lyt.obstruct_connection({2, 0}, {3, 0});  // blocks 3 paths
+            obstr_lyt.obstruct_connection({2, 0}, {3, 0});                                 // blocks 3 paths
 
             const auto path = jump_point_search<coord_path>(obstr_lyt, {{0, 0}, {3, 3}});  // only one path possible
 

--- a/test/algorithms/path_finding/k_shortest_paths.cpp
+++ b/test/algorithms/path_finding/k_shortest_paths.cpp
@@ -398,7 +398,7 @@ TEST_CASE("Yen's algorithm with coordinate obstruction but crossings enabled", "
             {
                 const gate_lyt layout{{2, 2, 1}, twoddwave_clocking<gate_lyt>()};  // create a crossing layer
 
-                SECTION("(0,0) to (2,2) with obstruction and crossings")  // 1 valid path
+                SECTION("(0,0) to (2,2) with obstruction and crossings")           // 1 valid path
                 {
                     obstruction_layout obstr_lyt{layout};
 
@@ -418,7 +418,7 @@ TEST_CASE("Yen's algorithm with coordinate obstruction but crossings enabled", "
             {
                 const gate_lyt layout{{2, 2, 1}, use_clocking<gate_lyt>()};  // create a crossing layer
 
-                SECTION("(0,0) to (2,2) with obstruction and crossings")  // 1 valid path
+                SECTION("(0,0) to (2,2) with obstruction and crossings")     // 1 valid path
                 {
                     obstruction_layout obstr_lyt{layout};
 
@@ -444,7 +444,7 @@ TEST_CASE("Yen's algorithm with coordinate obstruction but crossings enabled", "
             {
                 const gate_lyt layout{{3, 3, 1}, twoddwave_clocking<gate_lyt>()};  // create a crossing layer
 
-                SECTION("(0,0) to (3,3) with obstruction and crossings")  // 2 valid paths
+                SECTION("(0,0) to (3,3) with obstruction and crossings")           // 2 valid paths
                 {
                     obstruction_layout obstr_lyt{layout};
 
@@ -478,7 +478,7 @@ TEST_CASE("Yen's algorithm with coordinate obstruction but crossings enabled", "
             {
                 const gate_lyt layout{{3, 2, 1}, twoddwave_clocking<gate_lyt>()};  // create a crossing layer
 
-                SECTION("(0,0) to (3,2) with obstruction and crossings")  // 1 valid paths
+                SECTION("(0,0) to (3,2) with obstruction and crossings")           // 1 valid paths
                 {
                     obstruction_layout obstr_lyt{layout};
 

--- a/test/algorithms/physical_design/exact.cpp
+++ b/test/algorithms/physical_design/exact.cpp
@@ -696,7 +696,7 @@ TEST_CASE("Name conservation after exact physical design", "[exact]")
     CHECK(layout->get_output_name(0) == "f");
 }
 
-#else  // FICTION_Z3_SOLVER
+#else   // FICTION_Z3_SOLVER
 
 TEST_CASE("Exact physical design", "[exact]")
 {

--- a/test/algorithms/physical_design/one_pass_synthesis.cpp
+++ b/test/algorithms/physical_design/one_pass_synthesis.cpp
@@ -204,7 +204,7 @@ TEST_CASE("Name conservation after one-pass synthesis", "[one-pass]")
     CHECK(layout->get_output_name(0) == "f");
 }
 
-#else  // MUGEN
+#else   // MUGEN
 
 TEST_CASE("One-pass synthesis", "[one-pass]")
 {


### PR DESCRIPTION
## Description

This PR extends the ClangFormat configuration to standardize all line endings to use `LF`. It also reformats the project using ClangFormat 17.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
