### PR TITLE
redefinition of sidb_nm_position

### DIFF
--- a/include/fiction/algorithms/simulation/sidb/sidb_simulation_parameters.hpp
+++ b/include/fiction/algorithms/simulation/sidb/sidb_simulation_parameters.hpp
@@ -28,15 +28,14 @@ struct sidb_simulation_parameters
      * @param relative_permittivity it describes the electric field reduction due to polarization.
      * @param screening_distance also known as "Thomas-Fermi screening" and it describes the electric field screening
      * due to free charges.
-     * @param a lattice constant.
-     * @param b lattice constant.
-     * @param c lattice constant.
+     * @param a lattice constant in Å (Ångström).
+     * @param b lattice constant in Å.
+     * @param c lattice constant in Å.
      */
     constexpr explicit sidb_simulation_parameters(const uint8_t base_number = 3, const double mu_minus = -0.32,
                                                   const double relative_permittivity = 5.6,
-                                                  const double screening_distance    = 5.0 * 1E-9,
-                                                  const double a = 3.84 * 1E-10, const double b = 7.68 * 1E-10,
-                                                  const double c = 2.25 * 1E-10) :
+                                                  const double screening_distance = 5.0 * 1E-9, const double a = 3.84,
+                                                  const double b = 7.68, const double c = 2.25) :
             lat_a{a},
             lat_b{b},
             lat_c{c},

--- a/include/fiction/technology/charge_distribution_surface.hpp
+++ b/include/fiction/technology/charge_distribution_surface.hpp
@@ -88,7 +88,7 @@ class charge_distribution_surface<Lyt, false> : public Lyt
         /**
          * Distance between SiDBs are stored as matrix.
          */
-        distance_matrix dist_mat{};
+        distance_matrix dist_mat_nm{};
         /**
          * Electrostatic potential between SiDBs are stored as matrix (here, still charge-independent).
          */
@@ -225,7 +225,7 @@ class charge_distribution_surface<Lyt, false> : public Lyt
         else
         {
             strg->phys_params = params;
-            this->initialize_distance_matrix();
+            this->initialize_distance_nm_matrix();
             this->initialize_potential_matrix();
             strg->charge_index.second = params.base;
             strg->max_charge_index    = static_cast<uint64_t>(std::pow(strg->phys_params.base, this->num_cells())) - 1;
@@ -390,14 +390,14 @@ class charge_distribution_surface<Lyt, false> : public Lyt
      *
      *  @param c1 the first cell to compare.
      *  @param c2 the second cell to compare.
-     *  @return a constexpr double representing the distance between the two cells.
+     *  @return a constexpr double representing the distance in nm between the two cells.
      */
-    [[nodiscard]] double get_distance_between_cells(const typename Lyt::cell& c1,
-                                                    const typename Lyt::cell& c2) const noexcept
+    [[nodiscard]] double get_distance_nm_between_cells(const typename Lyt::cell& c1,
+                                                       const typename Lyt::cell& c2) const noexcept
     {
         if (const auto index1 = cell_to_index(c1), index2 = cell_to_index(c2); (index1 != -1) && (index2 != -1))
         {
-            return strg->dist_mat[static_cast<uint64_t>(index1)][static_cast<uint64_t>(index2)];
+            return strg->dist_mat_nm[static_cast<uint64_t>(index1)][static_cast<uint64_t>(index2)];
         }
 
         return 0;
@@ -409,9 +409,9 @@ class charge_distribution_surface<Lyt, false> : public Lyt
      * @param index2 The second index.
      * @return The distance index between `index1` and `index2` (indices correspond to unique SiDBs).
      */
-    [[nodiscard]] double get_distance_by_indices(const uint64_t index1, const uint64_t index2) const noexcept
+    [[nodiscard]] double get_distance_nm_by_indices(const uint64_t index1, const uint64_t index2) const noexcept
     {
-        return strg->dist_mat[index1][index2];
+        return strg->dist_mat_nm[index1][index2];
     }
     /**
      * Returns the chargeless electrostatic potential between two cells.
@@ -475,13 +475,13 @@ class charge_distribution_surface<Lyt, false> : public Lyt
      */
     [[nodiscard]] double potential_between_sidbs_by_index(const uint64_t index1, const uint64_t index2) const noexcept
     {
-        if (strg->dist_mat[index1][index2] == 0)
+        if (strg->dist_mat_nm[index1][index2] == 0)
         {
             return 0.0;
         }
 
-        return (strg->phys_params.k / strg->dist_mat[index1][index2] *
-                std::exp(-strg->dist_mat[index1][index2] / strg->phys_params.lambda_tf) *
+        return (strg->phys_params.k / (strg->dist_mat_nm[index1][index2] * 1E-9) *
+                std::exp(-strg->dist_mat_nm[index1][index2] * 1E-9 / strg->phys_params.lambda_tf) *
                 physical_constants::ELECTRIC_CHARGE);
     }
     /**
@@ -782,7 +782,7 @@ class charge_distribution_surface<Lyt, false> : public Lyt
             const auto dist_min =
                 std::accumulate(negative_indices.begin(), negative_indices.end(), std::numeric_limits<double>::max(),
                                 [&](const double acc, const uint64_t occ)
-                                { return std::min(acc, this->get_distance_by_indices(unocc, occ)); });
+                                { return std::min(acc, this->get_distance_nm_by_indices(unocc, occ)); });
 
             index_vector.push_back(unocc);
             distance.push_back(dist_min);
@@ -841,7 +841,7 @@ class charge_distribution_surface<Lyt, false> : public Lyt
                "number of SiDBs is too large");
 
         this->charge_distribution_to_index();
-        this->initialize_distance_matrix();
+        this->initialize_distance_nm_matrix();
         this->initialize_potential_matrix();
         strg->max_charge_index =
             static_cast<uint64_t>(std::pow(static_cast<double>(strg->phys_params.base), this->num_cells()) - 1);
@@ -853,15 +853,16 @@ class charge_distribution_surface<Lyt, false> : public Lyt
     /**
      * Initializes the distance matrix between all the cells of the layout.
      */
-    void initialize_distance_matrix() const noexcept
+    void initialize_distance_nm_matrix() const noexcept
     {
-        strg->dist_mat = std::vector<std::vector<double>>(this->num_cells(), std::vector<double>(this->num_cells(), 0));
+        strg->dist_mat_nm =
+            std::vector<std::vector<double>>(this->num_cells(), std::vector<double>(this->num_cells(), 0));
 
         for (uint64_t i = 0u; i < strg->sidb_order.size(); ++i)
         {
             for (uint64_t j = 0u; j < strg->sidb_order.size(); j++)
             {
-                strg->dist_mat[i][j] =
+                strg->dist_mat_nm[i][j] =
                     sidb_nanometer_distance<Lyt>(*this, strg->sidb_order[i], strg->sidb_order[j], strg->phys_params);
             }
         }

--- a/include/fiction/technology/charge_distribution_surface.hpp
+++ b/include/fiction/technology/charge_distribution_surface.hpp
@@ -88,7 +88,7 @@ class charge_distribution_surface<Lyt, false> : public Lyt
         /**
          * Distance between SiDBs are stored as matrix.
          */
-        distance_matrix dist_mat_nm{};
+        distance_matrix nm_dist_mat{};
         /**
          * Electrostatic potential between SiDBs are stored as matrix (here, still charge-independent).
          */
@@ -225,7 +225,7 @@ class charge_distribution_surface<Lyt, false> : public Lyt
         else
         {
             strg->phys_params = params;
-            this->initialize_distance_nm_matrix();
+            this->initialize_nm_distance_matrix();
             this->initialize_potential_matrix();
             strg->charge_index.second = params.base;
             strg->max_charge_index    = static_cast<uint64_t>(std::pow(strg->phys_params.base, this->num_cells())) - 1;
@@ -392,12 +392,12 @@ class charge_distribution_surface<Lyt, false> : public Lyt
      *  @param c2 the second cell to compare.
      *  @return a constexpr double representing the distance in nm between the two cells.
      */
-    [[nodiscard]] double get_distance_nm_between_cells(const typename Lyt::cell& c1,
+    [[nodiscard]] double get_nm_distance_between_cells(const typename Lyt::cell& c1,
                                                        const typename Lyt::cell& c2) const noexcept
     {
         if (const auto index1 = cell_to_index(c1), index2 = cell_to_index(c2); (index1 != -1) && (index2 != -1))
         {
-            return strg->dist_mat_nm[static_cast<uint64_t>(index1)][static_cast<uint64_t>(index2)];
+            return strg->nm_dist_mat[static_cast<uint64_t>(index1)][static_cast<uint64_t>(index2)];
         }
 
         return 0;
@@ -409,9 +409,9 @@ class charge_distribution_surface<Lyt, false> : public Lyt
      * @param index2 The second index.
      * @return The distance index between `index1` and `index2` (indices correspond to unique SiDBs).
      */
-    [[nodiscard]] double get_distance_nm_by_indices(const uint64_t index1, const uint64_t index2) const noexcept
+    [[nodiscard]] double get_nm_distance_by_indices(const uint64_t index1, const uint64_t index2) const noexcept
     {
-        return strg->dist_mat_nm[index1][index2];
+        return strg->nm_dist_mat[index1][index2];
     }
     /**
      * Returns the chargeless electrostatic potential between two cells.
@@ -475,13 +475,13 @@ class charge_distribution_surface<Lyt, false> : public Lyt
      */
     [[nodiscard]] double potential_between_sidbs_by_index(const uint64_t index1, const uint64_t index2) const noexcept
     {
-        if (strg->dist_mat_nm[index1][index2] == 0)
+        if (strg->nm_dist_mat[index1][index2] == 0)
         {
             return 0.0;
         }
 
-        return (strg->phys_params.k / (strg->dist_mat_nm[index1][index2] * 1E-9) *
-                std::exp(-strg->dist_mat_nm[index1][index2] * 1E-9 / strg->phys_params.lambda_tf) *
+        return (strg->phys_params.k / (strg->nm_dist_mat[index1][index2] * 1E-9) *
+                std::exp(-strg->nm_dist_mat[index1][index2] * 1E-9 / strg->phys_params.lambda_tf) *
                 physical_constants::ELECTRIC_CHARGE);
     }
     /**
@@ -782,7 +782,7 @@ class charge_distribution_surface<Lyt, false> : public Lyt
             const auto dist_min =
                 std::accumulate(negative_indices.begin(), negative_indices.end(), std::numeric_limits<double>::max(),
                                 [&](const double acc, const uint64_t occ)
-                                { return std::min(acc, this->get_distance_nm_by_indices(unocc, occ)); });
+                                { return std::min(acc, this->get_nm_distance_by_indices(unocc, occ)); });
 
             index_vector.push_back(unocc);
             distance.push_back(dist_min);
@@ -841,7 +841,7 @@ class charge_distribution_surface<Lyt, false> : public Lyt
                "number of SiDBs is too large");
 
         this->charge_distribution_to_index();
-        this->initialize_distance_nm_matrix();
+        this->initialize_nm_distance_matrix();
         this->initialize_potential_matrix();
         strg->max_charge_index =
             static_cast<uint64_t>(std::pow(static_cast<double>(strg->phys_params.base), this->num_cells()) - 1);
@@ -853,16 +853,16 @@ class charge_distribution_surface<Lyt, false> : public Lyt
     /**
      * Initializes the distance matrix between all the cells of the layout.
      */
-    void initialize_distance_nm_matrix() const noexcept
+    void initialize_nm_distance_matrix() const noexcept
     {
-        strg->dist_mat_nm =
+        strg->nm_dist_mat =
             std::vector<std::vector<double>>(this->num_cells(), std::vector<double>(this->num_cells(), 0));
 
         for (uint64_t i = 0u; i < strg->sidb_order.size(); ++i)
         {
             for (uint64_t j = 0u; j < strg->sidb_order.size(); j++)
             {
-                strg->dist_mat_nm[i][j] =
+                strg->nm_dist_mat[i][j] =
                     sidb_nanometer_distance<Lyt>(*this, strg->sidb_order[i], strg->sidb_order[j], strg->phys_params);
             }
         }

--- a/include/fiction/technology/sidb_nm_position.hpp
+++ b/include/fiction/technology/sidb_nm_position.hpp
@@ -27,8 +27,8 @@ constexpr std::pair<double, double> sidb_nm_position(const sidb_simulation_param
 {
     static_assert(has_siqad_coord_v<Lyt>, "Lyt is not based on SiQAD coordinates");
 
-    const auto x = static_cast<double>(c.x * sp.lat_a);
-    const auto y = static_cast<double>(c.y * sp.lat_b + c.z * sp.lat_c);
+    const auto x = static_cast<double>(c.x * sp.lat_a * 0.1);
+    const auto y = static_cast<double>(c.y * sp.lat_b * 0.1 + c.z * sp.lat_c * 0.1);
 
     return std::make_pair(x, y);
 }

--- a/test/technology/charge_distribution_surface.cpp
+++ b/test/technology/charge_distribution_surface.cpp
@@ -194,20 +194,20 @@ TEMPLATE_TEST_CASE(
 
         charge_distribution_surface charge_layout{lyt, sidb_simulation_parameters{}};
 
-        CHECK_THAT(charge_layout.get_distance_between_cells({0, 0, 0}, {0, 0, 0}),
+        CHECK_THAT(charge_layout.get_distance_nm_between_cells({0, 0, 0}, {0, 0, 0}),
                    Catch::Matchers::WithinAbs(0.0, 0.00001));
-        CHECK_THAT(charge_layout.get_distance_between_cells({0, 0, 0}, {1, 0, 0}),
-                   Catch::Matchers::WithinAbs(sidb_simulation_parameters{}.lat_a, 0.00001));
-        CHECK_THAT(charge_layout.get_distance_between_cells({1, 0, 0}, {0, 0, 0}),
-                   Catch::Matchers::WithinAbs(sidb_simulation_parameters{}.lat_a, 0.00001));
-        CHECK_THAT(charge_layout.get_distance_between_cells({1, 0, 0}, {1, 0, 0}),
+        CHECK_THAT(charge_layout.get_distance_nm_between_cells({0, 0, 0}, {1, 0, 0}),
+                   Catch::Matchers::WithinAbs(sidb_simulation_parameters{}.lat_a * 0.1, 0.00001));
+        CHECK_THAT(charge_layout.get_distance_nm_between_cells({1, 0, 0}, {0, 0, 0}),
+                   Catch::Matchers::WithinAbs(sidb_simulation_parameters{}.lat_a * 0.1, 0.00001));
+        CHECK_THAT(charge_layout.get_distance_nm_between_cells({1, 0, 0}, {1, 0, 0}),
                    Catch::Matchers::WithinAbs(0.0, 0.00001));
-        CHECK_THAT(charge_layout.get_distance_between_cells({0, 0, 0}, {1, 1, 1}),
+        CHECK_THAT(charge_layout.get_distance_nm_between_cells({0, 0, 0}, {1, 1, 1}),
                    Catch::Matchers::WithinAbs(
-                       std::hypot(sidb_simulation_parameters{}.lat_a,
-                                  sidb_simulation_parameters{}.lat_b + sidb_simulation_parameters{}.lat_c),
+                       std::hypot(sidb_simulation_parameters{}.lat_a * 0.1,
+                                  sidb_simulation_parameters{}.lat_b * 0.1 + sidb_simulation_parameters{}.lat_c * 0.1),
                        0.00001));
-        CHECK_THAT(charge_layout.get_distance_between_cells({1, 1, 1}, {1, 1, 1}),
+        CHECK_THAT(charge_layout.get_distance_nm_between_cells({1, 1, 1}, {1, 1, 1}),
                    Catch::Matchers::WithinAbs(0.0, 0.00001));
     }
 

--- a/test/technology/charge_distribution_surface.cpp
+++ b/test/technology/charge_distribution_surface.cpp
@@ -194,20 +194,20 @@ TEMPLATE_TEST_CASE(
 
         charge_distribution_surface charge_layout{lyt, sidb_simulation_parameters{}};
 
-        CHECK_THAT(charge_layout.get_distance_nm_between_cells({0, 0, 0}, {0, 0, 0}),
+        CHECK_THAT(charge_layout.get_nm_distance_between_cells({0, 0, 0}, {0, 0, 0}),
                    Catch::Matchers::WithinAbs(0.0, 0.00001));
-        CHECK_THAT(charge_layout.get_distance_nm_between_cells({0, 0, 0}, {1, 0, 0}),
+        CHECK_THAT(charge_layout.get_nm_distance_between_cells({0, 0, 0}, {1, 0, 0}),
                    Catch::Matchers::WithinAbs(sidb_simulation_parameters{}.lat_a * 0.1, 0.00001));
-        CHECK_THAT(charge_layout.get_distance_nm_between_cells({1, 0, 0}, {0, 0, 0}),
+        CHECK_THAT(charge_layout.get_nm_distance_between_cells({1, 0, 0}, {0, 0, 0}),
                    Catch::Matchers::WithinAbs(sidb_simulation_parameters{}.lat_a * 0.1, 0.00001));
-        CHECK_THAT(charge_layout.get_distance_nm_between_cells({1, 0, 0}, {1, 0, 0}),
+        CHECK_THAT(charge_layout.get_nm_distance_between_cells({1, 0, 0}, {1, 0, 0}),
                    Catch::Matchers::WithinAbs(0.0, 0.00001));
-        CHECK_THAT(charge_layout.get_distance_nm_between_cells({0, 0, 0}, {1, 1, 1}),
+        CHECK_THAT(charge_layout.get_nm_distance_between_cells({0, 0, 0}, {1, 1, 1}),
                    Catch::Matchers::WithinAbs(
                        std::hypot(sidb_simulation_parameters{}.lat_a * 0.1,
                                   sidb_simulation_parameters{}.lat_b * 0.1 + sidb_simulation_parameters{}.lat_c * 0.1),
                        0.00001));
-        CHECK_THAT(charge_layout.get_distance_nm_between_cells({1, 1, 1}, {1, 1, 1}),
+        CHECK_THAT(charge_layout.get_nm_distance_between_cells({1, 1, 1}, {1, 1, 1}),
                    Catch::Matchers::WithinAbs(0.0, 0.00001));
     }
 


### PR DESCRIPTION
## Description

Redefinition of ``sidb_nm_position``. The return value was previously in meters and was changed to nanometers for consistency.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
