### PR TITLE
:art: Changed the unit of the lambda-tf physical parameter from meter to nanometer

### DIFF
--- a/include/fiction/algorithms/simulation/sidb/sidb_simulation_parameters.hpp
+++ b/include/fiction/algorithms/simulation/sidb/sidb_simulation_parameters.hpp
@@ -63,7 +63,7 @@ struct sidb_simulation_parameters
      */
     double lat_c;
     /**
-     * epsilon_r is the electric permittivity. It is a material specific number.
+     * epsilon_r is the electric permittivity. It is a material specific number (unit-less).
      */
     double epsilon_r;
     /**

--- a/include/fiction/algorithms/simulation/sidb/sidb_simulation_parameters.hpp
+++ b/include/fiction/algorithms/simulation/sidb/sidb_simulation_parameters.hpp
@@ -27,14 +27,14 @@ struct sidb_simulation_parameters
      * @param mu_minus it is the energy transition level (0/-).
      * @param relative_permittivity it describes the electric field reduction due to polarization.
      * @param screening_distance also known as "Thomas-Fermi screening" and it describes the electric field screening
-     * due to free charges.
+     * due to free charges in nm.
      * @param a lattice constant in Å (Ångström).
      * @param b lattice constant in Å.
      * @param c lattice constant in Å.
      */
     constexpr explicit sidb_simulation_parameters(const uint8_t base_number = 3, const double mu_minus = -0.32,
                                                   const double relative_permittivity = 5.6,
-                                                  const double screening_distance = 5.0 * 1E-9, const double a = 3.84,
+                                                  const double screening_distance = 5.0, const double a = 3.84,
                                                   const double b = 7.68, const double c = 2.25) :
             lat_a{a},
             lat_b{b},
@@ -51,15 +51,15 @@ struct sidb_simulation_parameters
     }
 
     /**
-     * lat_a is the lattice vector in x-direction.
+     * lat_a is the lattice vector in x-direction (unit: Å).
      */
     double lat_a;
     /**
-     * lat_b is the lattice vector in y-direction.
+     * lat_b is the lattice vector in y-direction (unit: Å).
      */
     double lat_b;
     /**
-     * lat_c is the dimer pair separation.
+     * lat_c is the dimer pair separation (unit: Å).
      */
     double lat_c;
     /**
@@ -67,19 +67,19 @@ struct sidb_simulation_parameters
      */
     double epsilon_r;
     /**
-     * k is the Coulomb constant and is inversely proportional to the electric permittivity.
+     * k is the Coulomb constant and is inversely proportional to the electric permittivity (unit: SI).
      */
     double k;
     /**
-     * lambda_tf is the Thomas-Fermi screening distance.
+     * lambda_tf is the Thomas-Fermi screening distance (unit: nm).
      */
     double lambda_tf;
     /**
-     * µ- is the energy transition level (0/-)
+     * µ- is the energy transition level (0/-) (unit: eV).
      */
     double mu;
     /**
-     * µ+ is the energy transition level (+/0)
+     * µ+ is the energy transition level (+/0) (unit: eV).
      */
     double mu_p;
     /**

--- a/include/fiction/technology/charge_distribution_surface.hpp
+++ b/include/fiction/technology/charge_distribution_surface.hpp
@@ -481,7 +481,7 @@ class charge_distribution_surface<Lyt, false> : public Lyt
         }
 
         return (strg->phys_params.k / (strg->nm_dist_mat[index1][index2] * 1E-9) *
-                std::exp(-strg->nm_dist_mat[index1][index2] * 1E-9 / strg->phys_params.lambda_tf) *
+                std::exp(-strg->nm_dist_mat[index1][index2] / strg->phys_params.lambda_tf) *
                 physical_constants::ELECTRIC_CHARGE);
     }
     /**

--- a/test/technology/charge_distribution_surface.cpp
+++ b/test/technology/charge_distribution_surface.cpp
@@ -417,7 +417,7 @@ TEMPLATE_TEST_CASE(
     SECTION("using chargeless and normal potential function")
     {
         TestType                         lyt_new{{11, 11}};
-        const sidb_simulation_parameters params{3, -0.32, 5.0 * 1E-9, 3.84 * 1E-10, 7.68 * 1E-10, 2.25 * 1E-10};
+        const sidb_simulation_parameters params{3, -0.32, 5.0, 3.84, 7.68, 2.25};
 
         lyt_new.assign_cell_type({0, 0, 1}, TestType::cell_type::NORMAL);
         lyt_new.assign_cell_type({1, 3, 0}, TestType::cell_type::NORMAL);


### PR DESCRIPTION
## Description

This PR changes the unit of ``lambda_tf`` (parameter for the physical simulation of SiDBs) from meter to nanometer.



## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
