### PR TITLE
🐛 Fix test skips based on Z3

### DIFF
--- a/.github/workflows/pyfiction-pypi-deployment.yml
+++ b/.github/workflows/pyfiction-pypi-deployment.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           z3: ${{env.ENABLE_Z3}}
           CIBW_BEFORE_ALL_LINUX: /opt/python/cp39-cp39/bin/pip install z3-solver==${{ env.Z3_VERSION }}
-          CIBW_TEST_REQUIRES: test
+          CIBW_TEST_EXTRAS: test
           CIBW_TEST_COMMAND: 'python -m unittest discover --start-directory {project} --verbose'
 
       - name: Upload wheel as an artifact

--- a/.github/workflows/pyfiction-pypi-deployment.yml
+++ b/.github/workflows/pyfiction-pypi-deployment.yml
@@ -57,6 +57,7 @@ jobs:
         env:
           z3: ${{env.ENABLE_Z3}}
           CIBW_BEFORE_ALL_LINUX: /opt/python/cp39-cp39/bin/pip install z3-solver==${{ env.Z3_VERSION }}
+          CIBW_TEST_REQUIRES: test
           CIBW_TEST_COMMAND: 'python -m unittest discover --start-directory {project} --verbose'
 
       - name: Upload wheel as an artifact

--- a/.github/workflows/python-bindings.yml
+++ b/.github/workflows/python-bindings.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Build pyfiction
         working-directory: ${{github.workspace}}
-        run: z3=${{env.ENABLE_Z3}} pip install .
+        run: z3=${{env.ENABLE_Z3}} pip install '.[test]'
 
       - name: Test
         working-directory: ${{github.workspace}}/bindings/pyfiction/test

--- a/bindings/pyfiction/README.md
+++ b/bindings/pyfiction/README.md
@@ -35,7 +35,7 @@ Alternatively, install the following dependency before the `CMake` call:
 pip install python-dotenv==0.21.1
 ```
 
-To execute all tests, use the following command inside in the package directory:
+To execute all tests, use the following command inside the package directory:
 
 ```bash
  python -m unittest discover --verbose

--- a/bindings/pyfiction/README.md
+++ b/bindings/pyfiction/README.md
@@ -21,6 +21,26 @@ cd build
 cmake --build . -j4
 ```
 
+### Enabling and running tests
+
+To run tests locally, build the binding with its dependencies using `pip`:
+
+```bash
+pip install '.[test]'
+```
+
+Alternatively, install the following dependency before the `CMake` call:
+
+```bash
+pip install python-dotenv==0.21.1
+```
+
+To execute all tests, use the following command inside in the package directory:
+
+```bash
+ python -m unittest discover --verbose
+```
+
 ## Usage
 
 The bindings are available as a Python module named `pyfiction` in the namespace `mnt`. To use the bindings, simply

--- a/bindings/pyfiction/test/algorithms/physical_design/test_apply_gate_library.py
+++ b/bindings/pyfiction/test/algorithms/physical_design/test_apply_gate_library.py
@@ -1,8 +1,10 @@
 from fiction.pyfiction import *
+from dotenv import load_dotenv
 import unittest
 import os
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
+load_dotenv()
 z3 = os.environ.get("z3", "OFF")
 
 

--- a/bindings/pyfiction/test/algorithms/physical_design/test_exact.py
+++ b/bindings/pyfiction/test/algorithms/physical_design/test_exact.py
@@ -1,8 +1,10 @@
 from fiction.pyfiction import *
+from dotenv import load_dotenv
 import unittest
 import os
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
+load_dotenv()
 z3 = os.environ.get("z3", "OFF")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ requires = [
     "setuptools_scm[toml]>=7",
     "ninja>=1.10; sys_platform != 'win32'",
     "cmake>=3.15",
-    "python-dotenv>=1.0.0"
 ]
 build-backend = "setuptools.build_meta"
 
@@ -35,6 +34,7 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)',
 ]
 
+dependencies = ["python-dotenv>=1.0.0"]
 requires-python = ">=3.7"
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
     "setuptools_scm[toml]>=7",
     "ninja>=1.10; sys_platform != 'win32'",
     "cmake>=3.15",
+    "python-dotenv>=1.0.0"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)',
 ]
 
-dependencies = ["python-dotenv==0.21.1"]
 requires-python = ">=3.7"
 
 [project.urls]
@@ -42,6 +41,11 @@ Source = 'https://github.com/marcelwa/fiction'
 Tracker = 'https://github.com/marcelwa/fiction/issues'
 Documentation = 'https://fiction.readthedocs.io/en/latest/'
 Research = 'https://www.cda.cit.tum.de/research/fcn/'
+
+[project.optional-dependencies]
+test = [
+    "python-dotenv==0.21.1"
+]
 
 [tool.setuptools.packages.find]
 include = ["bindings/pyfiction.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)',
 ]
 
-dependencies = ["python-dotenv>=1.0.0"]
+dependencies = ["python-dotenv==0.21.1"]
 requires-python = ">=3.7"
 
 [project.urls]


### PR DESCRIPTION
## Description

Use `python-dotenv` to load environment variables from `.env`.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
