### PR TITLE
:bug: Specify build OS in readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,6 +2,8 @@ version: 2
 
 build:
   os: ubuntu-22.04
+  tools:
+    python: "3.7"
 
 submodules:
   exclude: all
@@ -13,6 +15,5 @@ sphinx:
 formats: [ ]
 
 python:
-  version: "3.7"
   install:
     - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,8 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+
 submodules:
   exclude: all
   recursive: false
@@ -7,7 +10,7 @@ submodules:
 sphinx:
   configuration: docs/conf.py
 
-formats: []
+formats: [ ]
 
 python:
   version: "3.7"


### PR DESCRIPTION
## Description

This PR adds the specification of the build OS to prevent sphinx issue. Due to a latest update of sphinx, readthedocs are not build anymore (https://github.com/readthedocs/readthedocs-docker-images/issues/194).


## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
