### PR TITLE
:bug: Fixed port routing determination for unconnected gates in the Bestagon library

### DIFF
--- a/include/fiction/technology/sidb_bestagon_library.hpp
+++ b/include/fiction/technology/sidb_bestagon_library.hpp
@@ -320,14 +320,27 @@ class sidb_bestagon_library : public fcn_gate_library<sidb_technology, 60, 46>  
             p.out.emplace(port_direction::cardinal::SOUTH_WEST);
         }
 
-        // has no connector ports
-        if (const auto n = lyt.get_node(t); !lyt.is_wire(n) && !lyt.is_inv(n))
+        // gates without connector ports
+
+        // 1-input functions
+        if (const auto n = lyt.get_node(t); lyt.is_pi(n) || lyt.is_po(n) || lyt.is_buf(n) || lyt.is_inv(n))
         {
             if (lyt.has_no_incoming_signal(t))
             {
                 p.inp.emplace(port_direction::cardinal::NORTH_WEST);
             }
-
+            if (lyt.has_no_outgoing_signal(t))
+            {
+                p.out.emplace(port_direction::cardinal::SOUTH_EAST);
+            }
+        }
+        else  // 2-input functions
+        {
+            if (lyt.has_no_incoming_signal(t))
+            {
+                p.inp.emplace(port_direction::cardinal::NORTH_WEST);
+                p.inp.emplace(port_direction::cardinal::NORTH_EAST);
+            }
             if (lyt.has_no_outgoing_signal(t))
             {
                 p.out.emplace(port_direction::cardinal::SOUTH_EAST);


### PR DESCRIPTION
## Description

When using the Bestagon gate library, it was impossible to map gates without connections. This has been fixed. Many thanks to @wlambooy for reporting!

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [ ] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
