### PR TITLE
:sparkles: Enable charge distribution surface printing

### DIFF
--- a/include/fiction/io/print_layout.hpp
+++ b/include/fiction/io/print_layout.hpp
@@ -314,7 +314,7 @@ void print_cell_level_layout(std::ostream& os, const Lyt& layout, const bool io_
     os << std::endl;
 }
 /**
- * Writes a simplified 2D representation of an  cell-level layout to an output stream.
+ * Writes a simplified 2D representation of a charge distribution surface to an output stream.
  *
  * @tparam Lyt Cell-level layout based in SiQAD-coordinates.
  * @param os Output stream to write into.
@@ -344,14 +344,13 @@ void print_charge_distribution_surface(std::ostream& os, const charge_distributi
 
             if (Lyt::technology::is_normal_cell(ct))
             {
-                const auto& db_locs = cds.get_all_sidb_locations_in_nm();
-
-                const auto& it = std::find(db_locs.cbegin(), db_locs.cend(),
+                const auto& it = std::find(cds.get_all_sidb_locations_in_nm().cbegin(),
+                                           cds.get_all_sidb_locations_in_nm().cend(),
                                            sidb_nm_position<Lyt>(cds.get_phys_params(), c));
 
-                if (it != db_locs.cend())
+                if (it != cds.get_all_sidb_locations_in_nm().cend())
                 {
-                    switch (cds.get_all_sidb_charges()[std::distance(db_locs.cbegin(), it)])
+                    switch (cds.get_all_sidb_charges()[std::distance(cds.get_all_sidb_locations_in_nm().cbegin(), it)])
                     {
                         case sidb_charge_state::NEGATIVE:
                         {

--- a/include/fiction/io/print_layout.hpp
+++ b/include/fiction/io/print_layout.hpp
@@ -315,15 +315,15 @@ void print_cell_level_layout(std::ostream& os, const Lyt& layout, const bool io_
     os << std::endl;
 }
 /**
- * Writes a simplified 2D representation of a charge distribution surface to an output stream.
+ * Writes a simplified 2D representation of a SiDB charge layout to an output stream.
  *
  * @tparam Lyt Cell-level layout based in SiQAD-coordinates.
  * @param os Output stream to write into.
- * @param cds The charge distribution surface to print.
+ * @param cds The charge distribution surface of which the charge layout is to be printed.
  * @param cs_color Flag to utilize color escapes for charge states.
  */
 template <typename Lyt>
-void print_charge_distribution_surface(std::ostream& os, const charge_distribution_surface<Lyt>& cds,
+void print_charge_layout(std::ostream& os, const charge_distribution_surface<Lyt>& cds,
                                        const bool cs_color = false) noexcept
 {
     // empty layout

--- a/include/fiction/io/print_layout.hpp
+++ b/include/fiction/io/print_layout.hpp
@@ -5,6 +5,7 @@
 #ifndef FICTION_PRINT_LAYOUT_HPP
 #define FICTION_PRINT_LAYOUT_HPP
 
+#include "fiction/technology/charge_distribution_surface.hpp"
 #include "fiction/traits.hpp"
 #include "fiction/types.hpp"
 


### PR DESCRIPTION
## Description

This PR introduces a simple method for printing charge distribution surface objects to a console. An optional flag may be passed (defaulting to false) which enables colored output in the same color scheme as SiQAD.  