### PR TITLE
:sparkles: SiQAD coordinate iteration

### DIFF
--- a/docs/layouts/coordinates.rst
+++ b/docs/layouts/coordinates.rst
@@ -12,8 +12,6 @@ An offset coordinate is a coordinate that defines a location via an offset from 
 
 .. doxygenstruct:: fiction::offset::ucoord_t
 
-.. doxygenclass:: fiction::offset::coord_iterator
-
 Cube coordinates
 ----------------
 
@@ -23,12 +21,19 @@ At the same time, they can be used to address 3-dimensional grids.
 .. doxygenstruct:: fiction::cube::coord_t
 
 SiQAD coordinates
-----------------
+-----------------
 
-SiQAD coordinates are used to describe locations of Silicon Dangling Bonds on the H-Si(100) 2x1 surface were dimer columns and rows are identified by x and y values, respecitvely,
+SiQAD coordinates are used to describe locations of Silicon Dangling Bonds on the H-Si(100) 2x1 surface were dimer columns and rows are identified by x and y values, respectively,
 while the z value (0,1) points to the top or bottom Si atom in the dimer. The coordinates are originally used in the SiQAD simulator (https://github.com/siqad).
 
 .. doxygenstruct:: fiction::siqad::coord_t
+
+Coordinate iterator
+-------------------
+
+An iterator type that allows to enumerate coordinates in order within a boundary.
+
+.. doxygenclass:: fiction::coord_iterator
 
 Utility functions
 -----------------

--- a/include/fiction/layouts/cartesian_layout.hpp
+++ b/include/fiction/layouts/cartesian_layout.hpp
@@ -628,8 +628,8 @@ class cartesian_layout
     [[nodiscard]] auto coordinates(const OffsetCoordinateType& start = {}, const OffsetCoordinateType& stop = {}) const
     {
         return range_t{std::make_pair(
-            offset::coord_iterator{strg->dimension, start.is_dead() ? OffsetCoordinateType{0, 0} : start},
-            offset::coord_iterator{strg->dimension, stop.is_dead() ? strg->dimension.get_dead() : stop})};
+            coord_iterator{strg->dimension, start.is_dead() ? OffsetCoordinateType{0, 0} : start},
+            coord_iterator{strg->dimension, stop.is_dead() ? strg->dimension.get_dead() : stop})};
     }
     /**
      * Applies a function to all coordinates accessible in the layout between `start` and `stop`. The iteration order is
@@ -645,8 +645,8 @@ class cartesian_layout
                             const OffsetCoordinateType& stop = {}) const
     {
         mockturtle::detail::foreach_element(
-            offset::coord_iterator{strg->dimension, start.is_dead() ? OffsetCoordinateType{0, 0} : start},
-            offset::coord_iterator{strg->dimension, stop.is_dead() ? strg->dimension.get_dead() : stop}, fn);
+            coord_iterator{strg->dimension, start.is_dead() ? OffsetCoordinateType{0, 0} : start},
+            coord_iterator{strg->dimension, stop.is_dead() ? strg->dimension.get_dead() : stop}, fn);
     }
     /**
      * Returns a range of all coordinates accessible in the layout's ground layer between `start` and `stop`. The
@@ -665,8 +665,8 @@ class cartesian_layout
         const auto ground_layer = aspect_ratio{x(), y(), 0};
 
         return range_t{
-            std::make_pair(offset::coord_iterator{ground_layer, start.is_dead() ? OffsetCoordinateType{0, 0} : start},
-                           offset::coord_iterator{ground_layer, stop.is_dead() ? ground_layer.get_dead() : stop})};
+            std::make_pair(coord_iterator{ground_layer, start.is_dead() ? OffsetCoordinateType{0, 0} : start},
+                           coord_iterator{ground_layer, stop.is_dead() ? ground_layer.get_dead() : stop})};
     }
     /**
      * Applies a function to all coordinates accessible in the layout's ground layer between `start` and `stop`. The
@@ -686,8 +686,8 @@ class cartesian_layout
         const auto ground_layer = aspect_ratio{x(), y(), 0};
 
         mockturtle::detail::foreach_element(
-            offset::coord_iterator{ground_layer, start.is_dead() ? OffsetCoordinateType{0, 0} : start},
-            offset::coord_iterator{ground_layer, stop.is_dead() ? ground_layer.get_dead() : stop}, fn);
+            coord_iterator{ground_layer, start.is_dead() ? OffsetCoordinateType{0, 0} : start},
+            coord_iterator{ground_layer, stop.is_dead() ? ground_layer.get_dead() : stop}, fn);
     }
     /**
      * Returns a container that contains all coordinates that are adjacent to a given one. Thereby, only cardinal

--- a/include/fiction/layouts/cartesian_layout.hpp
+++ b/include/fiction/layouts/cartesian_layout.hpp
@@ -621,7 +621,7 @@ class cartesian_layout
      * will be iterated first, then y, then z.
      *
      * @param start First coordinate to include in the range of all coordinates.
-     * @param stop Last coordinate to include in the range of all coordinates.
+     * @param stop Last coordinate (exclusive) to include in the range of all coordinates.
      * @return An iterator range from `start` to `stop`. If they are not provided, the first/last coordinate is used as
      * a default.
      */
@@ -638,7 +638,7 @@ class cartesian_layout
      * @tparam Fn Functor type that has to comply with the restrictions imposed by `mockturtle::foreach_element`.
      * @param fn Functor to apply to each coordinate in the range.
      * @param start First coordinate to include in the range of all coordinates.
-     * @param stop Last coordinate to include in the range of all coordinates.
+     * @param stop Last coordinate (exclusive) to include in the range of all coordinates.
      */
     template <typename Fn>
     void foreach_coordinate(Fn&& fn, const OffsetCoordinateType& start = {},
@@ -653,7 +653,7 @@ class cartesian_layout
      * iteration order is the same as for the coordinates function but without the z dimension.
      *
      * @param start First coordinate to include in the range of all ground coordinates.
-     * @param stop Last coordinate to include in the range of all ground coordinates.
+     * @param stop Last coordinate (exclusive) to include in the range of all ground coordinates.
      * @return An iterator range from `start` to `stop`. If they are not provided, the first/last coordinate in the
      * ground layer is used as a default.
      */
@@ -675,7 +675,7 @@ class cartesian_layout
      * @tparam Fn Functor type that has to comply with the restrictions imposed by `mockturtle::foreach_element`.
      * @param fn Functor to apply to each coordinate in the range.
      * @param start First coordinate to include in the range of all ground coordinates.
-     * @param stop Last coordinate to include in the range of all ground coordinates.
+     * @param stop Last coordinate (exclusive) to include in the range of all ground coordinates.
      */
     template <typename Fn>
     void foreach_ground_coordinate(Fn&& fn, const OffsetCoordinateType& start = {},

--- a/include/fiction/layouts/coordinates.hpp
+++ b/include/fiction/layouts/coordinates.hpp
@@ -7,9 +7,11 @@
 
 #include <fmt/format.h>
 
+#include <cassert>
 #include <cstdint>
 #include <functional>
 #include <iostream>
+#include <type_traits>
 
 // data types cannot properly be converted to bit field types
 #pragma GCC diagnostic push
@@ -25,6 +27,7 @@ namespace fiction
  */
 namespace offset
 {
+
 /**
  * Unsigned offset coordinates.
  *
@@ -252,114 +255,6 @@ inline std::ostream& operator<<(std::ostream& os, const ucoord_t& t)
     return os;
 }
 
-/**
- * An iterator type that allows to enumerate coordinates in order within a boundary.
- *
- * @tparam CoordinateType Type of coordinate to enumerate.
- */
-template <typename CoordinateType>
-class coord_iterator
-{
-  public:
-    using value_type = CoordinateType;
-    /**
-     * Standard constructor. Initializes the iterator with a starting position and the boundary within to enumerate.
-     *
-     * With `dimension = (1, 2, 1)` and `start = (0, 0, 0)`, the following order would be enumerated:
-     *
-     * - (0, 0, 0)
-     * - (1, 0, 0)
-     * - (0, 1, 0)
-     * - (1, 1, 0)
-     * - (0, 2, 0)
-     * - (1, 2, 0)
-     * - (0, 0, 1)
-     * - (1, 0, 1)
-     * - (0, 1, 1)
-     * - (1, 1, 1)
-     * - (0, 2, 1)
-     * - (1, 2, 1)
-     *
-     * coord_iterator is compatible with the STL forward_iterator category.
-     *
-     * @param dimension Boundary within to enumerate. Iteration wraps at its limits.
-     * @param start Starting coordinate to enumerate first.
-     */
-    constexpr explicit coord_iterator(const CoordinateType& dimension, const CoordinateType& start) noexcept :
-            aspect_ratio{dimension},
-            coord{start}
-    {}
-    /**
-     * Increments the iterator.
-     *
-     * @return Reference to the incremented iterator.
-     */
-    constexpr coord_iterator& operator++() noexcept
-    {
-        if (coord != aspect_ratio)
-        {
-            ++coord.x;
-
-            if (coord.x > aspect_ratio.x)
-            {
-                coord.x = 0;
-
-                ++coord.y;
-                if (coord.y > aspect_ratio.y)
-                {
-                    coord.y = 0;
-
-                    ++coord.z;
-                }
-            }
-        }
-        else
-        {
-            coord = coord.get_dead();
-        }
-
-        return *this;
-    }
-
-    constexpr coord_iterator operator++(int) noexcept
-    {
-        const auto result{*this};
-
-        ++(*this);
-
-        return result;
-    }
-
-    constexpr CoordinateType operator*() const noexcept
-    {
-        return coord;
-    }
-
-    constexpr bool operator==(const coord_iterator& other) const noexcept
-    {
-        return (coord == other.coord);
-    }
-
-    constexpr bool operator!=(const coord_iterator& other) const noexcept
-    {
-        return !(*this == other);
-    }
-
-    constexpr bool operator<(const coord_iterator& other) const noexcept
-    {
-        return (coord < other.coord);
-    }
-
-    constexpr bool operator<=(const coord_iterator& other) const noexcept
-    {
-        return (coord <= other.coord);
-    }
-
-  private:
-    const CoordinateType aspect_ratio;
-
-    CoordinateType coord;
-};
 }  // namespace offset
 
 /**
@@ -368,6 +263,7 @@ class coord_iterator
  */
 namespace cube
 {
+
 /**
  * Signed cube coordinates.
  *
@@ -832,10 +728,132 @@ constexpr coord_t to_siqad_coord(const CoordinateType& coord) noexcept
 
 }  // namespace siqad
 
+/**
+ * An iterator type that allows to enumerate coordinates in order within a boundary.
+ *
+ * @tparam CoordinateType Type of coordinate to enumerate.
+ */
+template <typename CoordinateType>
+class coord_iterator
+{
+  public:
+    using value_type = CoordinateType;
+    /**
+     * Standard constructor. Initializes the iterator with a starting position and the boundary within to enumerate.
+     *
+     * With `dimension = (1, 2, 1)` and `start = (0, 0, 0)`, the following order would be enumerated:
+     *
+     * - (0, 0, 0)
+     * - (1, 0, 0)
+     * - (0, 1, 0)
+     * - (1, 1, 0)
+     * - (0, 2, 0)
+     * - (1, 2, 0)
+     * - (0, 0, 1)
+     * - (1, 0, 1)
+     * - (0, 1, 1)
+     * - (1, 1, 1)
+     * - (0, 2, 1)
+     * - (1, 2, 1)
+     *
+     * coord_iterator is compatible with the STL forward_iterator category.
+     *
+     * @param dimension Boundary within to enumerate. Iteration wraps at its limits.
+     * @param start Starting coordinate to enumerate first.
+     */
+    constexpr explicit coord_iterator(const CoordinateType& dimension, const CoordinateType& start) noexcept :
+            aspect_ratio{dimension},
+            coord{start}
+    {}
+    /**
+     * Increments the iterator.
+     *
+     * @return Reference to the incremented iterator.
+     */
+    constexpr coord_iterator& operator++() noexcept
+    {
+        if (coord != aspect_ratio)
+        {
+            ++coord.x;
+
+            if (coord.x > aspect_ratio.x)
+            {
+                coord.x = 0;
+
+                if constexpr (std::is_same_v<CoordinateType, offset::ucoord_t>)
+                {
+                    ++coord.y;
+                    if (coord.y > aspect_ratio.y)
+                    {
+                        coord.y = 0;
+
+                        ++coord.z;
+                    }
+                }
+                else if constexpr (std::is_same_v<CoordinateType, siqad::coord_t>)
+                {
+                    coord.y += coord.z;
+                    coord.z = !coord.z;
+                }
+                else
+                {
+                    assert(false && "Unsupported coordinate type");
+                }
+            }
+        }
+        else
+        {
+            coord = coord.get_dead();
+        }
+
+        return *this;
+    }
+
+    constexpr coord_iterator operator++(int) noexcept
+    {
+        const auto result{*this};
+
+        ++(*this);
+
+        return result;
+    }
+
+    constexpr CoordinateType operator*() const noexcept
+    {
+        return coord;
+    }
+
+    constexpr bool operator==(const coord_iterator& other) const noexcept
+    {
+        return (coord == other.coord);
+    }
+
+    constexpr bool operator!=(const coord_iterator& other) const noexcept
+    {
+        return !(*this == other);
+    }
+
+    constexpr bool operator<(const coord_iterator& other) const noexcept
+    {
+        return (coord < other.coord);
+    }
+
+    constexpr bool operator<=(const coord_iterator& other) const noexcept
+    {
+        return (coord <= other.coord);
+    }
+
+  private:
+    const CoordinateType aspect_ratio;
+
+    CoordinateType coord;
+};
+
 }  // namespace fiction
 
 namespace std
 {
+
 // define std::hash overload for offset::ucoord_t
 template <>
 struct hash<fiction::offset::ucoord_t>
@@ -866,17 +884,19 @@ struct hash<fiction::siqad::coord_t>
     }
 };
 
-// make offset::coord_iterator compatible with STL iterator categories
+// make coord_iterator compatible with STL iterator categories
 template <typename Coordinate>
-struct iterator_traits<fiction::offset::coord_iterator<Coordinate>>
+struct iterator_traits<fiction::coord_iterator<Coordinate>>
 {
     using iterator_category = std::forward_iterator_tag;
     using value_type        = Coordinate;
 };
+
 }  // namespace std
 
 namespace fmt
 {
+
 // make offset::ucoord_t compatible with fmt::format
 template <>
 struct formatter<fiction::offset::ucoord_t>
@@ -909,6 +929,7 @@ struct formatter<fiction::cube::coord_t>
         return format_to(ctx.out(), "({},{},{})", c.x, c.y, c.z);
     }
 };
+
 }  // namespace fmt
 
 #pragma GCC diagnostic pop

--- a/include/fiction/layouts/hexagonal_layout.hpp
+++ b/include/fiction/layouts/hexagonal_layout.hpp
@@ -800,8 +800,8 @@ class hexagonal_layout
     [[nodiscard]] auto coordinates(const OffsetCoordinateType& start = {}, const OffsetCoordinateType& stop = {}) const
     {
         return range_t{std::make_pair(
-            offset::coord_iterator{strg->dimension, start.is_dead() ? OffsetCoordinateType{0, 0} : start},
-            offset::coord_iterator{strg->dimension, stop.is_dead() ? strg->dimension.get_dead() : stop})};
+            coord_iterator{strg->dimension, start.is_dead() ? OffsetCoordinateType{0, 0} : start},
+            coord_iterator{strg->dimension, stop.is_dead() ? strg->dimension.get_dead() : stop})};
     }
     /**
      * Applies a function to all coordinates accessible in the layout between `start` and `stop`. The iteration order is
@@ -817,8 +817,8 @@ class hexagonal_layout
                             const OffsetCoordinateType& stop = {}) const
     {
         mockturtle::detail::foreach_element(
-            offset::coord_iterator{strg->dimension, start.is_dead() ? OffsetCoordinateType{0, 0} : start},
-            offset::coord_iterator{strg->dimension, stop.is_dead() ? strg->dimension.get_dead() : stop}, fn);
+            coord_iterator{strg->dimension, start.is_dead() ? OffsetCoordinateType{0, 0} : start},
+            coord_iterator{strg->dimension, stop.is_dead() ? strg->dimension.get_dead() : stop}, fn);
     }
     /**
      * Returns a range of all coordinates accessible in the layout's ground layer between `start` and `stop`. The
@@ -837,8 +837,8 @@ class hexagonal_layout
         auto ground_layer = aspect_ratio{x(), y(), 0};
 
         return range_t{
-            std::make_pair(offset::coord_iterator{ground_layer, start.is_dead() ? OffsetCoordinateType{0, 0} : start},
-                           offset::coord_iterator{ground_layer, stop.is_dead() ? ground_layer.get_dead() : stop})};
+            std::make_pair(coord_iterator{ground_layer, start.is_dead() ? OffsetCoordinateType{0, 0} : start},
+                           coord_iterator{ground_layer, stop.is_dead() ? ground_layer.get_dead() : stop})};
     }
     /**
      * Applies a function to all coordinates accessible in the layout's ground layer between `start` and `stop`. The
@@ -858,8 +858,8 @@ class hexagonal_layout
         auto ground_layer = aspect_ratio{x(), y(), 0};
 
         mockturtle::detail::foreach_element(
-            offset::coord_iterator{ground_layer, start.is_dead() ? OffsetCoordinateType{0, 0} : start},
-            offset::coord_iterator{ground_layer, stop.is_dead() ? ground_layer.get_dead() : stop}, fn);
+            coord_iterator{ground_layer, start.is_dead() ? OffsetCoordinateType{0, 0} : start},
+            coord_iterator{ground_layer, stop.is_dead() ? ground_layer.get_dead() : stop}, fn);
     }
     /**
      * Returns a container that contains all coordinates that are adjacent to a given one. Thereby, cardinal and ordinal

--- a/include/fiction/layouts/hexagonal_layout.hpp
+++ b/include/fiction/layouts/hexagonal_layout.hpp
@@ -793,7 +793,7 @@ class hexagonal_layout
      * will be iterated first, then y, then z.
      *
      * @param start First coordinate to include in the range of all coordinates.
-     * @param stop Last coordinate to include in the range of all coordinates.
+     * @param stop Last coordinate (exclusive) to include in the range of all coordinates.
      * @return An iterator range from `start` to `stop`. If they are not provided, the first/last coordinate is used as
      * a default.
      */
@@ -810,7 +810,7 @@ class hexagonal_layout
      * @tparam Fn Functor type that has to comply with the restrictions imposed by `mockturtle::foreach_element`.
      * @param fn Functor to apply to each coordinate in the range.
      * @param start First coordinate to include in the range of all coordinates.
-     * @param stop Last coordinate to include in the range of all coordinates.
+     * @param stop Last coordinate (exclusive) to include in the range of all coordinates.
      */
     template <typename Fn>
     void foreach_coordinate(Fn&& fn, const OffsetCoordinateType& start = {},
@@ -825,7 +825,7 @@ class hexagonal_layout
      * iteration order is the same as for the coordinates function but without the z dimension.
      *
      * @param start First coordinate to include in the range of all ground coordinates.
-     * @param stop Last coordinate to include in the range of all ground coordinates.
+     * @param stop Last coordinate (exclusive) to include in the range of all ground coordinates.
      * @return An iterator range from `start` to `stop`. If they are not provided, the first/last coordinate in the
      * ground layer is used as a default.
      */
@@ -847,7 +847,7 @@ class hexagonal_layout
      * @tparam Fn Functor type that has to comply with the restrictions imposed by `mockturtle::foreach_element`.
      * @param fn Functor to apply to each coordinate in the range.
      * @param start First coordinate to include in the range of all ground coordinates.
-     * @param stop Last coordinate to include in the range of all ground coordinates.
+     * @param stop Last coordinate (exclusive) to include in the range of all ground coordinates.
      */
     template <typename Fn>
     void foreach_ground_coordinate(Fn&& fn, const OffsetCoordinateType& start = {},

--- a/test/io/print_layout.cpp
+++ b/test/io/print_layout.cpp
@@ -215,7 +215,7 @@ TEST_CASE("Print Bestagon OR-gate", "[print-charge-layout]")
 {
     using hex_gate_lyt = hex_even_row_gate_clk_lyt;
 
-    hex_gate_lyt layout{{1, 0}};
+    hex_gate_lyt layout{aspect_ratio<hex_gate_lyt>{1, 0, 1}};
 
     layout.create_or({}, {}, {0, 0});
 
@@ -253,7 +253,7 @@ TEST_CASE("Print Bestagon OR-gate", "[print-charge-layout]")
         " ·  ·  ◯  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ●  ·  · \n"
         " ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  · \n"
         "\n"
-        " ·  ·  ·  ·  ◌  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ●  ·  ·  ·  · \n"
+        " ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ●  ·  ·  ·  · \n"
         " ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  · \n"
         "\n"
         " ·  ·  ·  ·  ·  ·  ·  ·  ●  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ◯  ·  ·  ·  ·  ·  ·  ·  · \n"
@@ -272,7 +272,7 @@ TEST_CASE("Print Bestagon OR-gate", "[print-charge-layout]")
         " ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  · \n"
         "\n"
         " ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ⨁  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  · \n"
-        " ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ◌  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  · \n"
+        " ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  · \n"
         "\n"
         " ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  · \n"
         " ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ●  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  · \n"

--- a/test/layouts/coordinates.cpp
+++ b/test/layouts/coordinates.cpp
@@ -4,6 +4,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <fiction/layouts/cartesian_layout.hpp>
 #include <fiction/layouts/coordinates.hpp>
 
 #include <map>
@@ -84,9 +85,8 @@ TEST_CASE("Unsigned offset coordinates", "[coordinates]")
     CHECK(os.str() == "(3,2,1)");
 }
 
-TEST_CASE("siqad coordinate conversion", "[coordinates]")
+TEST_CASE("SiQAD coordinate conversion", "[coordinates]")
 {
-
     using coordinate         = siqad::coord_t;
     using coordinate_fiction = cube::coord_t;
 
@@ -122,6 +122,32 @@ TEST_CASE("siqad coordinate conversion", "[coordinates]")
     auto t5_fiction = siqad::to_fiction_coord<coordinate_fiction>(t5_siqad);
     CHECK(t5_fiction.x == -1);
     CHECK(t5_fiction.y == -3);
+}
+
+TEST_CASE("Offset coordinate iteration", "[coordinates]")
+{
+    using lyt = cartesian_layout<offset::ucoord_t>;
+
+    std::stringstream print_stream;
+
+    lyt {{1,1,1}}.foreach_coordinate([&ps = print_stream](const auto& c) { ps << c.str(); });
+
+    constexpr const char* coordinates_string = "(0,0,0)(1,0,0)(0,1,0)(1,1,0)(0,0,1)(1,0,1)(0,1,1)(1,1,1)";
+
+    CHECK(coordinates_string == print_stream.str());
+}
+
+TEST_CASE("SiQAD coordinate iteration", "[coordinates]")
+{
+    using lyt = cartesian_layout<siqad::coord_t>;
+
+    std::stringstream print_stream;
+
+    lyt {{1,1,1}}.foreach_coordinate([&ps = print_stream](const auto& c) { ps << c.str(); });
+
+    constexpr const char* coordinates_string = "(0,0,0)(1,0,0)(0,0,1)(1,0,1)(0,1,0)(1,1,0)(0,1,1)(1,1,1)";
+
+    CHECK(coordinates_string == print_stream.str());
 }
 
 #if defined(__GNUC__)


### PR DESCRIPTION
## Description

This PR extracts `coord_iterator` from the `offset` namespace and instead allows for specialisations depending on the `CoordinateType` template argument. The default implementation for offset coordinates is left in tact, and a specialisation for SiQAD coordinates is added. Additionally, `print_charge_layout` is updated to use this new way of iteration over SiQAD coordinates.

Lastly, a mistake in the documentation of `coordinate`, `ground_coordinate`, `foreach_coordinate`, and `foreach_ground_coordinate` was found: the end bound was stated to be inclusive, but this is not the case. I have added `(exclusive)` in order to avoid further confusion.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
